### PR TITLE
Fix #283, make the simple_op example to work by fixing the dict iteration

### DIFF
--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -229,7 +229,7 @@ class Provider(object):
 
             match = False
             for regbase, rquery in self.cdb[str(areq["client_id"])][
-                "redirect_uris"]:
+                "redirect_uris"].items():
                 # The URI MUST exactly match one of the Redirection URI
                 if _base == regbase:
                     # every registered query component must exist in the


### PR DESCRIPTION
As I mentioned in #283, oidc_example/simple_op cannot work because of a dictionary iteration issue. 

In https://github.com/OpenIDC/pyoidc/blob/master/src/oic/oauth2/provider.py#L231-L232, `self.cdb[str(areq["client_id"])]["redirect_uris"]` is a dictionary and we are trying to iterate this dictionary and unpack the dictionary item into key (regbase) and value (rquery). However, we have to call `items()` when iterating a dictionary this way.

I can make the example to work after fixing this issue in the source. (But I made some additional change to the oidc_example/simple_op example itself, which probably can be submitted as another PR later).