### PR TITLE
Drop 3.4.4 and cover more relevant versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ addons:
 
 matrix:
   include:
-    - python: 3.5.2
-      env: TOXENV=py35 BUILD=code
-    - python: 3.4.4
-      env: TOXENV=py34 BUILD=code
     - python: 2.7
       env: TOXENV=py27 BUILD=code
-    - python: 3.5.2
+    - python: 3.5
+      env: TOXENV=py35 BUILD=code
+    - python: 3.6
+      env: TOXENV=py36 BUILD=code
+    - python: 3.5
       env: TOXENV=py35 BUILD=docs
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on the [KeepAChangeLog] project.
 
 [KeepAChangeLog]: http://keepachangelog.com/
 
+## 0.9.6.0 [UNRELEASED]
+
+### Changed
+- [#291]: Testing more relevant Python versions.
+
+[#291]: https://github.com/OpenIDC/pyoidc/pull/291
+
 ## 0.9.5.0 [2017-03-22]
 
 ### Added


### PR DESCRIPTION
2.7, 3.5 and 3.6 are tested now.