### PR TITLE
Fixup documentation building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ foo.*
 
 # Dynamically created doc folders
 doc/_build
-doc/index/*
 !tests/data/keys
 
 # Remaining stuff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ The format is based on the [KeepAChangeLog] project.
 ### Changed
 - [#291]: Testing more relevant Python versions.
 
+### Removed
+- [#294]: Generating code indices in documentation.
+
 [#291]: https://github.com/OpenIDC/pyoidc/pull/291
+[#294]: https://github.com/OpenIDC/pyoidc/pull/294
 
 ## 0.9.5.0 [2017-03-22]
 

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,12 @@ PROJECT_ROOT:=.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXABUILD  = sphinx-autobuild
-SPHINXAPIDOC  = sphinx-apidoc
 BUILDDIR      = doc/_build
 DOCDIR        = doc/
-INDEXDIR      = doc/index
 OICDIR        = src/oic
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  index      to make HTML code index files"
 	@echo "  html       to make HTML documentation files"
 	@echo "  livehtml   to make HTML documentation files (live reload!)"
 	@echo "  install    to install the python dependencies for development"
@@ -22,11 +19,6 @@ clean:
 	rm -rf $(INDEXDIR)
 	rm -rf $(BUILDDIR)/*
 .PHONY: clean
-
-index:
-	$(SPHINXAPIDOC) -F -o $(INDEXDIR) $(OICDIR)
-	@echo "Build finished. The Index pages are in $(INDEXDIR)."
-.PHONY: index
 
 ALLSPHINXOPTS=-W
 html:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ REQS_DIR=$(PROJECT_ROOT)/requirements
 BASE_DEPS:=$(REQS_DIR)/base.txt
 TEST_DEPS:=$(REQS_DIR)/test.txt
 ADMIN_DEPS:=$(REQS_DIR)/admin.txt
-ALL_REQS:=$(BASE_DEPS) $(TEST_DEPS) $(ADMIN_DEPS)
+DOC_DEPS:=$(REQS_DIR)/docs.txt
+ALL_REQS:=$(BASE_DEPS) $(TEST_DEPS) $(ADMIN_DEPS) $(DOC_DEPS)
 reqs: $(ALL_REQS)
 upgrade:
 	$(RM) $(ALL_REQS)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,57 +1,34 @@
 import alabaster
 
-# -- General configuration ------------------------------------------------
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = [
     'sphinx.ext.autodoc',
 ]
 
-# Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-# The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
 master_doc = 'index'
 
-# General information about the project.
 project = u'pyoidc'
+
 copyright = u'2014, Roland Hedberg'
 
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-# The short X.Y version.
 version = '0.1'
-# The full version, including alpha/beta/rc tags.
+
 release = '0.1'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
 exclude_patterns = ['_build']
 
-# The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
-# -- Options for HTML output ----------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
 html_theme_path = [alabaster.get_path()]
+
 html_theme = 'alabaster'
-html_sidebars = {
-   '**': [
-       'about.html',
-       'navigation.html',
-       'searchbox.html',
-       'donate.html',
-   ]
-}
+
+html_static_path = ['_static']
+
+htmlhelp_basename = 'pyoidcdoc'
 
 html_theme_options = {
    'description': '',
@@ -62,42 +39,27 @@ html_theme_options = {
 
 }
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_sidebars = {
+   '**': [
+       'about.html',
+       'navigation.html',
+       'searchbox.html',
+       'donate.html',
+   ]
+}
 
-# Output file base name for HTML help builder.
-htmlhelp_basename = 'pyoidcdoc'
-
-
-# -- Options for LaTeX output ---------------------------------------------
-
-latex_elements = {}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-  ('index', 'pyoidc.tex', u'pyoidc Documentation',
-   u'Roland Hedberg', 'manual'),
-]
-
-
-# -- Options for manual page output ---------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'pyoidc', u'pyoidc Documentation',
      [u'Roland Hedberg'], 1)
 ]
 
-# -- Options for Texinfo output -------------------------------------------
+latex_elements = {}
 
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
+latex_documents = [
+  ('index', 'pyoidc.tex', u'pyoidc Documentation',
+   u'Roland Hedberg', 'manual'),
+]
+
 texinfo_documents = [
   ('index', 'pyoidc', u'pyoidc Documentation',
    u'Roland Hedberg', 'pyoidc', 'One line description of project.',

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,11 +25,6 @@ Installation is simple with Pip_:
    contrib/testing
    contrib/documentation
 
-Please use the following indices to review the code base:
-
-* :ref:`genindex`
-* :ref:`modindex`
-
 .. raw:: html
 
     <a href="https://github.com/rohe/pyoidc" class="github" target="_blank">

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,17 +1,19 @@
-PyOIDC
-======
+A Python OpenID Connect implementation
+======================================
 
-One of the most complete implementations of OpenID Connect. And as a side
-effect, a fairly complete implementation of OAuth2.0.
+This is a complete implementation of OpenID Connect as specified in the `OpenID
+Connect Core specification`_. And as a side effect, a complete implementation
+of OAuth2.0 too.
 
-Installation is simple with Pip_:
+.. _OpenID Connect Core specification: http://openid.net/specs/openid-connect-core-1_0.html.
+
+Getting a copy is simple with Pip_:
 
 .. _Pip: http://pip.pypa.io/
 
 ::
 
   $ pip install -U oic
-
 
 .. toctree::
    :maxdepth: 1

--- a/requirements/admin.in
+++ b/requirements/admin.in
@@ -1,1 +1,3 @@
+# Administrative dependencies
+
 pip-tools

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,3 +1,5 @@
+# Base essential dependencies
+
 requests
 cryptography
 cffi

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,6 +4,5 @@ cffi
 pyjwkest
 mako
 beaker
-alabaster
 pyOpenSSL
 pyldap

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,3 @@
-alabaster==0.7.10
 appdirs==1.4.3            # via setuptools
 asn1crypto==0.22.0        # via cryptography
 beaker==1.8.1

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,0 +1,4 @@
+# Documentation dependencies
+
+Sphinx
+sphinx-autobuild

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,20 @@
+alabaster==0.7.10         # via sphinx
+argh==0.26.2              # via sphinx-autobuild, watchdog
+babel==2.3.4              # via sphinx
+docutils==0.13.1          # via sphinx
+imagesize==0.7.1          # via sphinx
+Jinja2==2.9.5             # via sphinx
+livereload==2.5.1         # via sphinx-autobuild
+MarkupSafe==1.0           # via jinja2
+pathtools==0.1.2          # via sphinx-autobuild, watchdog
+port_for==0.3.1           # via sphinx-autobuild
+Pygments==2.2.0           # via sphinx
+pytz==2016.10             # via babel
+PyYAML==3.12              # via sphinx-autobuild, watchdog
+requests==2.13.0          # via sphinx
+six==1.10.0               # via livereload, sphinx
+snowballstemmer==1.2.1    # via sphinx
+sphinx-autobuild==0.6.0
+Sphinx==1.5.3
+tornado==4.4.2            # via livereload, sphinx-autobuild
+watchdog==0.8.3           # via sphinx-autobuild

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,4 +1,5 @@
--r base.txt
+# Development dependencies
+# Depends on base.in
 
 pytest
 httpretty

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,30 +1,17 @@
-alabaster==0.7.10
-appdirs==1.4.3
-asn1crypto==0.22.0
-beaker==1.8.1
-cffi==1.10.0
+-r base.txt
+appdirs==1.4.3            # via setuptools
 cookies==2.2.1            # via responses
-cryptography==1.8.1
-future==0.16.0
 httpretty==0.8.14
-idna==2.5
-mako==1.0.6
-MarkupSafe==1.0           # via mako
 mock==2.0.0
-packaging==16.8
+packaging==16.8           # via setuptools
 pbr==2.0.0                # via mock
 py==1.4.33                # via pytest
-pycparser==2.17
-pycryptodomex==3.4.5
-pyjwkest==1.3.2
-pyldap==2.4.28
-pyOpenSSL==16.2.0
-pyparsing==2.2.0
+pyparsing==2.2.0          # via packaging
 pytest==3.0.7
-requests==2.13.0
+requests==2.13.0          # via responses
 responses==0.5.1
-six==1.10.0
+six==1.10.0               # via mock, packaging, responses, setuptools
 testfixtures==4.13.5
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools                # via cryptography, pyldap, pytest
+# setuptools                # via pytest


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [x] The documentation has been updated, if necessary.

---

So, the two main things I have done here are:

  1) Remove code index generation
  2) Add a separate documentation dependency

Why? For 1), I think the index generation depends on the library being installed, which we cannot have installed on the readthedocs platform because the `pyldap` dependency requires some system dependencies, and readthedocs cannot install anything on the system (phew!).

For 2), well, I don't know why this was missing but it should be a seperate dependency.