### PR TITLE
Add future to dependencies, upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on the [KeepAChangeLog] project.
 ### Changed
 - [#291]: Testing more relevant Python versions.
 - [#296]: `parse_qs` import from `future.backports` to `future.moves`.
+- [#188]: Added `future` dependency, updated dependecies
 
 ### Removed
 - [#294]: Generating code indices in documentation.
@@ -21,6 +22,7 @@ The format is based on the [KeepAChangeLog] project.
 [#294]: https://github.com/OpenIDC/pyoidc/pull/294
 [#295]: https://github.com/OpenIDC/pyoidc/pull/295
 [#296]: https://github.com/OpenIDC/pyoidc/pull/296
+[#188]: https://github.com/OpenIDC/pyoidc/issues/188
 
 ## 0.9.5.0 [2017-03-22]
 

--- a/requirements/admin.txt
+++ b/requirements/admin.txt
@@ -1,4 +1,4 @@
 click==6.7                # via pip-tools
 first==2.0.1              # via pip-tools
-pip-tools==1.8.0
+pip-tools==1.8.1
 six==1.10.0               # via pip-tools

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,3 +8,4 @@ mako
 beaker
 pyOpenSSL
 pyldap
+future

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,19 +3,20 @@ asn1crypto==0.22.0        # via cryptography
 beaker==1.8.1
 cffi==1.10.0
 cryptography==1.8.1
-future==0.16.0            # via pyjwkest
+enum34==1.1.6             # via cryptography
+future==0.16.0
 idna==2.5                 # via cryptography
+ipaddress==1.0.18         # via cryptography
 mako==1.0.6
-MarkupSafe==1.0           # via mako
 packaging==16.8           # via cryptography, setuptools
 pycparser==2.17           # via cffi
 pycryptodomex==3.4.5      # via pyjwkest
 pyjwkest==1.3.2
 pyldap==2.4.28
-pyOpenSSL==16.2.0
+pyopenssl==16.2.0
 pyparsing==2.2.0          # via packaging
 requests==2.13.0
-six==1.10.0               # via cryptography, packaging, pyjwkest, pyopenssl, setuptools
+six==1.10.0               # via cryptography, packaging, pyjwkest, setuptools
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via cryptography, pyldap

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,20 +1,23 @@
 alabaster==0.7.10         # via sphinx
 argh==0.26.2              # via sphinx-autobuild, watchdog
-babel==2.3.4              # via sphinx
+babel==2.4.0              # via sphinx
+backports-abc==0.5        # via tornado
+certifi==2017.1.23        # via tornado
 docutils==0.13.1          # via sphinx
 imagesize==0.7.1          # via sphinx
-Jinja2==2.9.5             # via sphinx
+jinja2==2.9.5             # via sphinx
 livereload==2.5.1         # via sphinx-autobuild
-MarkupSafe==1.0           # via jinja2
+markupsafe==1.0           # via jinja2
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
-port_for==0.3.1           # via sphinx-autobuild
-Pygments==2.2.0           # via sphinx
+port-for==0.3.1           # via sphinx-autobuild
+pygments==2.2.0           # via sphinx
 pytz==2016.10             # via babel
-PyYAML==3.12              # via sphinx-autobuild, watchdog
+pyyaml==3.12              # via sphinx-autobuild, watchdog
 requests==2.13.0          # via sphinx
-six==1.10.0               # via livereload, sphinx
+singledispatch==3.4.0.3   # via tornado
+six==1.10.0               # via livereload, singledispatch, sphinx
 snowballstemmer==1.2.1    # via sphinx
 sphinx-autobuild==0.6.0
-Sphinx==1.5.3
+sphinx==1.5.3
 tornado==4.4.2            # via livereload, sphinx-autobuild
 watchdog==0.8.3           # via sphinx-autobuild

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,13 +4,12 @@ cookies==2.2.1            # via responses
 httpretty==0.8.14
 mock==2.0.0
 packaging==16.8           # via setuptools
-pbr==2.0.0                # via mock
 py==1.4.33                # via pytest
 pyparsing==2.2.0          # via packaging
 pytest==3.0.7
 requests==2.13.0          # via responses
 responses==0.5.1
-six==1.10.0               # via mock, packaging, responses, setuptools
+six==1.10.0               # via packaging, responses, setuptools
 testfixtures==4.13.5
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
As mentioned in #188 `future` is used in the code explicitly, thus it should be present in requirements.

Close #188

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [x] The documentation has been updated, if necessary.

---
