### PR TITLE
Add test coverage to CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,7 @@ install:
   - pip install tox
 
 script:
-  - tox -e $TOX_ENV
+  - tox -e coverage-erase,$TOX_ENV
+
+after_success:
+  - tox -e coveralls

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@
 .. image:: https://readthedocs.org/projects/pyoidc/badge/?version=latest
     :target: http://pyoidc.readthedocs.io/en/latest/?badge=latest
 
+.. image:: https://coveralls.io/repos/github/OpenIDC/pyoidc/badge.svg?branch=master
+    :target: https://coveralls.io/github/OpenIDC/pyoidc?branch=master
+
 .. image:: https://landscape.io/github/OpenIDC/pyoidc/master/landscape.svg?style=flat
     :target: https://landscape.io/github/OpenIDC/pyoidc/master
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,6 +3,7 @@
 
 tox
 pytest
+pytest-cov
 httpretty
 responses
 mock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 -r base.txt
 appdirs==1.4.3            # via setuptools
 cookies==2.2.1            # via responses
+coverage==4.3.4           # via pytest-cov
 httpretty==0.8.14
 mock==2.0.0
 packaging==16.8           # via setuptools
@@ -8,6 +9,7 @@ pbr==2.0.0                # via mock
 pluggy==0.4.0             # via tox
 py==1.4.33                # via pytest, tox
 pyparsing==2.2.0          # via packaging
+pytest-cov==2.4.0
 pytest==3.0.7
 requests==2.13.0          # via responses
 responses==0.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,15 @@
 envlist = py{27,34,36},docs,quality
 
 [testenv]
-commands = py.test tests/ -m "not network" {posargs}
-deps = -rrequirements/test.txt
+setenv =
+    COVERAGE_FILE = {toxinidir}/.coverage.{envname}
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+commands =
+    py.test --cov-report= --cov=oic tests/ -m "not network" {posargs}
+    ; Transform absolute path to relative path for compatibility with coveralls.io and fix 'source not available' error.
+    python -c "import os;cov_strip_abspath = open(os.environ['COVERAGE_FILE'], 'r').read().replace('.tox' + os.sep + os.path.relpath('{envsitepackagesdir}', '{toxworkdir}'), 'src');open(os.environ['COVERAGE_FILE'], 'w').write(cov_strip_abspath)"
+deps =
+    -rrequirements/test.txt
 
 [testenv:docs]
 whitelist_externals = make
@@ -16,6 +23,32 @@ deps = -rrequirements/quality.txt
 commands =
     make check-isort
     make check-pylama
+
+[testenv:coveralls]
+setenv =
+    COVERAGE_FILE = {toxinidir}/.coverage
+passenv =
+    *
+deps =
+    coverage
+    coveralls
+skip_install = true
+commands =
+    coverage combine
+    coveralls
+changedir = {toxinidir}
+
+[testenv:coverage-erase]
+setenv =
+    COVERAGE_FILE = {toxinidir}/.coverage
+passenv =
+    *
+deps =
+    coverage
+skip_install = true
+commands =
+    coverage erase
+changedir = {toxinidir}
 
 [pep8]
 max-line-length=100


### PR DESCRIPTION
Adding test coverage to CI.
We will need to enable Coveralls.

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.

---
