### PR TITLE
Fix python 3 input syntax for python 2 support

### DIFF
--- a/src/oic/utils/client_management.py
+++ b/src/oic/utils/client_management.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from future.backports.urllib.parse import splitquery
 from future.backports.urllib.parse import urlparse
 from future.moves.urllib.parse import parse_qs
+from builtins import input
+
 
 import argparse
 import copy


### PR DESCRIPTION
In PR #117 commit 4e1ae5ab8a889b57a59f9c5d9ecf6df04fdaaf4f breaks the client_management module under Python 2 because of the change of the input builtin in Python 3.

This imports the Python 3 function from `future`

Fixes #330 

