### PR TITLE
Fix python 3 input syntax for python 2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on the [KeepAChangeLog] project.
 ### Fixed
 - [#313]: Catch exception correctly
 - [#319]: Fix sanitize on strings starting with "B" or "U"
+- [#330]: Fix client_management user input being eval'd under Python 2
 
 ### Changed
 - [#318]: `oic.utils.authn.saml` raises `ImportError` on import if optional `saml2` dependency is not present.

--- a/src/oic/utils/client_management.py
+++ b/src/oic/utils/client_management.py
@@ -10,6 +10,7 @@ import json
 import os
 import shelve
 import sys
+from builtins import input
 
 from oic import rndstr
 from oic.oic.provider import secret


### PR DESCRIPTION
In PR #117 commit 4e1ae5ab8a889b57a59f9c5d9ecf6df04fdaaf4f breaks the client_management module under Python 2 because of the change of the input builtin in Python 3.

This imports the Python 3 function from `future`

Fixes #330 

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.

---
