### PR TITLE
Changed the ACR default value

### DIFF
--- a/oidc_example/rp3/conf.py.example
+++ b/oidc_example/rp3/conf.py.example
@@ -24,7 +24,8 @@ BEHAVIOUR = {
     "scope": ["openid", "profile", "email", "address", "phone"],
 }
 
-ACR_VALUES = ["SAML"]
+ACR_VALUES = ["PASSWORD"]
+# Other possible values: SAML
 
 # The keys in this dictionary are the OPs short userfriendly name
 # not the issuer (iss) name.


### PR DESCRIPTION
Providers are commonly "password-based", so I think its better if the default value for `ACR` is `password`, not `SAML`

Thanks for contributing to this library! Please include the following check
list in your pull request submission (you can delete this message). If your
changes don't need a change log or documentation update, please ignore this.

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.

---
