### PR TITLE
Use urljoin instead of os.path.join when joining URLs

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -12,7 +12,6 @@ import hmac
 import itertools
 import json
 import logging
-import os
 import random
 import socket
 import sys
@@ -1663,7 +1662,7 @@ class Provider(AProvider):
 
         for endp in self.endp:
             # _log_info("# %s, %s" % (endp, endp.name))
-            _provider_info['{}_endpoint'.format(endp.etype)] = os.path.join(
+            _provider_info['{}_endpoint'.format(endp.etype)] = urljoin(
                 self.baseurl,
                 endp.url)
 


### PR DESCRIPTION
Fix #344.