### PR TITLE
Issuer with path

### DIFF
--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -970,12 +970,13 @@ class Client(oauth2.Client):
     def provider_config(self, issuer, keys=True, endpoints=True,
                         response_cls=ProviderConfigurationResponse,
                         serv_pattern=OIDCONF_PATTERN):
-        if issuer.endswith("/"):
-            _issuer = issuer[:-1]
-        else:
-            _issuer = issuer
 
-        url = serv_pattern % _issuer
+        # Issuer MAY contain a path element, but webfinger .well-known URLs
+        # are always rooted at the top (RFC 5785), so this must be normalized
+        # and any path component discarded.
+        _authority = "{0.scheme}://{0.netloc}".format(urlparse(_issuer))
+
+        url = serv_pattern % _authority
 
         pcr = None
         r = self.http_request(url, allow_redirects=True)

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -974,7 +974,7 @@ class Client(oauth2.Client):
         # Issuer MAY contain a path element, but webfinger .well-known URLs
         # are always rooted at the top (RFC 5785), so this must be normalized
         # and any path component discarded.
-        _authority = "{0.scheme}://{0.netloc}".format(urlparse(_issuer))
+        _authority = "{0.scheme}://{0.netloc}".format(urlparse(issuer))
 
         url = serv_pattern % _authority
 


### PR DESCRIPTION
Allow an issuer with a path in the provider_config method.

This normalizes the issuer down to scheme + netloc and fixes #346.