### PR TITLE
Status code can be 400, 401, 403 or .. !

### DIFF
--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -849,7 +849,7 @@ class Client(oauth2.Client):
                 sformat = "jwt"
         elif resp.status_code == 500:
             raise PyoidcError("ERROR: Something went wrong: %s" % resp.text)
-        elif resp.status_code == 400:
+        elif 400 <= resp.status_code < 500 :
             # the response text might be a OIDC message
             try:
                 res = ErrorResponse().from_json(resp.text)

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -849,7 +849,7 @@ class Client(oauth2.Client):
                 sformat = "jwt"
         elif resp.status_code == 500:
             raise PyoidcError("ERROR: Something went wrong: %s" % resp.text)
-        elif 400 <= resp.status_code < 500 :
+        elif 400 <= resp.status_code < 500:
             # the response text might be a OIDC message
             try:
                 res = ErrorResponse().from_json(resp.text)

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -837,7 +837,7 @@ class Client(oauth2.Client):
 
         try:
             resp = self.http_request(path, method, data=body, **h_args)
-        except oauth2.MissingRequiredAttribute:
+        except oauth2.exception.MissingRequiredAttribute:
             raise
 
         if resp.status_code == 200:
@@ -1437,8 +1437,12 @@ class Server(oauth2.Server):
     def handle_request_uri(self, request_uri, verify=True, sender=''):
         """
 
-        :param areq:
-        :param redirect_uri:
+        :param request_uri: URL pointing to where the signed request should
+        be fetched from.
+        :param verify: Whether the signature on the request should be verified.
+        Don't use anything but the default unless you REALLY know what you're
+        doing
+        :param sender: The issuer of the request JWT.
         :return:
         """
 


### PR DESCRIPTION
According to RFC6749 an OP shall return a 400 when it encounters an error in processing a request.
The OIDC core document in section 5.3.3 in the example uses 401.
During conformance testing I've also seen 403's in some cases.
So, there is reason to widen then scope for possible status_code denoting protocol errors.

The fact that I've seen software return a 200 with an error message is another matter and is already covered in the code.