### PR TITLE
Win test failures

### DIFF
--- a/src/oic/oauth2/consumer.py
+++ b/src/oic/oauth2/consumer.py
@@ -32,10 +32,25 @@ def stateID(url, seed):
     :param url: The base URL for this site
     :return: The hex version of the digest
     """
+    # Seed may be bytes or unicode
+    try:
+        seed = seed.encode()
+    except AttributeError:
+        pass
+
     ident = md5()
     ident.update(repr(time.time()).encode())
     ident.update(url.encode())
     ident.update(seed)
+    # Mix in some randomness, as time.time() does not have enough
+    # accuracy on all platforms to make this unique for identical
+    # seeds and urls.
+    # The accuracy can be pretty bad, around 20ms, unless one uses
+    # one of the high precision timers (e.g. py3 timeit.default_timer())
+    # that use stuff like the performance counters in the CPU.
+    # But even that can and does break on VMs, where the performance counters
+    # are virtualized too, so better play safe than sorry here.
+    ident.update(rndstr(8).encode())
     return ident.hexdigest()
 
 

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 import logging
 import os.path
-import time
-from hashlib import md5
 
 from oic import rndstr
 from oic.exception import AuthzError
@@ -10,6 +8,7 @@ from oic.exception import PyoidcError
 from oic.oauth2 import Grant
 from oic.oauth2.consumer import TokenError
 from oic.oauth2.consumer import UnknownState
+from oic.oauth2.consumer import stateID
 from oic.oauth2.message import ErrorResponse
 from oic.oic import ENDPOINTS
 from oic.oic import Client
@@ -24,20 +23,6 @@ from oic.utils.sanitize import sanitize
 __author__ = 'rohe0002'
 
 logger = logging.getLogger(__name__)
-
-
-def stateID(url, seed):
-    """The hash of the time + server path + a seed makes an unique
-    SID for each session.
-
-    :param url: The base URL for this site
-    :return: The hex version of the digest
-    """
-    ident = md5()
-    ident.update(repr(time.time()).encode())
-    ident.update(url.encode())
-    ident.update(seed.encode())
-    return ident.hexdigest()
 
 
 def factory(kaka, sdb, config):

--- a/tests/test_time_util.py
+++ b/tests/test_time_util.py
@@ -199,8 +199,7 @@ def test_time_a_while_ago():
     dt = datetime.utcnow()
     t = time_a_while_ago(seconds=10)
     delta = dt - t  # slightly less than 10
-    assert delta.seconds == 9
-    assert delta.microseconds > 0
+    assert (delta.seconds == 9 and delta.microseconds > 0) or delta.seconds == 10
 
 
 def test_a_while_ago():


### PR DESCRIPTION
Fixes some broken tests on Windows:

- stateID() was not unique when called twice, due to the low clock resolution on windows, so the clock timestamp didn't change between the
two test calls
- stateID code was duplicated between oauth2/consumer.py and oic/consumer.py
- test_begin_file makes invalid assumptions about the externally visible URL path and the local filesystem path
- test_a_while_ago falls into the same trap as stateID() and does not account for the fact that time is quantized/discreet instead of continous