### PR TITLE
Better token crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ The format is based on the [KeepAChangeLog] project.
 - [#318]: `oic.utils.authn.saml` raises `ImportError` on import if optional `saml2` dependency is not present.
 - [#325]: `oic.oic.claims_match` implementation refactored.
 
+### Security
+- [#349]: Changed crypto algorithm used by `oic.utils.sdb.Crypt` for token encryption to Fernet. Old stored tokens are incompatible. 
+
 [#313]: https://github.com/OpenIDC/pyoidc/issues/313
 [#318]: https://github.com/OpenIDC/pyoidc/pull/318
 [#319]: https://github.com/OpenIDC/pyoidc/pull/319
 [#325]: https://github.com/OpenIDC/pyoidc/pull/325
+[#349]: https://github.com/OpenIDC/pyoidc/issues/349
 
 ## 0.10.0.0 [2017-03-28]
 


### PR DESCRIPTION
This fixes the constant IV issue in #349 by using the fernet scheme to do the encryption.

This does not yet add a KDF function to stretch a weak password into some stronger key. This is okay if the 'password' is not really a password but a high entropy key. 

It is still 'padding compatible' with the old Crypt code, even if the benefits of manual padding to the AES blocksize seems doubtful.