### PR TITLE
Serialize the AuthnEvent when adding to session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ The format is based on the [KeepAChangeLog] project.
 
 ## 0.11.0.0 [UNRELEASED]
 
+### Changed
 - [#324]: Make the Provider `symkey` argument optional.
 
+### Fixed
+- [#369]: The AuthnEvent object is now serialized to JSON for the session.
+
 [#324]: https://github.com/OpenIDC/pyoidc/pull/324
+[#369]: https://github.com/OpenIDC/pyoidc/pull/369
 
 ## 0.10.0.1 [UNRELEASED]
 

--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,9 @@ Maintainers Needed
 If you're interested in helping maintain and improve this package, we're
 looking for you!
 
-Please contact one of the current maintainers, `@lwm`_, `@rohe`_ or `@tpazderka`_.
+Please contact one of the current maintainers, `@lwm`_, `@rohe`_, `@tpazderka`_ or `@schlenk`_.
 
 .. _@lwm: https://github.com/lwm/
 .. _@rohe: https://github.com/rohe/
 .. _@tpazderka: https://github.com/tpazderka/
+.. _@schlenk: https://github.com/schlenk

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -776,10 +776,11 @@ class Provider(AProvider):
 
         if "check_session_iframe" in self.capabilities:
             salt = rndstr()
-            state = str(self.sdb.get_authentication_event(
-                sid).authn_time)  # use the last session
+            authn_event = self.sdb.get_authentication_event(sid)  # use the last session
+            state = str(authn_event["authn_time"])
             aresp["session_state"] = self._compute_session_state(
-                state, salt, areq["client_id"], redirect_uri)
+                state, salt, areq["client_id"], redirect_uri
+            )
             headers.append(self.write_session_cookie(state))
 
         # as per the mix-up draft don't add iss and client_id if they are
@@ -888,9 +889,9 @@ class Provider(AProvider):
 
         _authn_event = sinfo["authn_event"]
         id_token = self.id_token_as_signed_jwt(
-            sinfo, loa=_authn_event.authn_info, alg=alg, code=code,
+            sinfo, loa=_authn_event["authn_info"], alg=alg, code=code,
             access_token=access_token, user_info=user_info,
-            auth_time=_authn_event.authn_time)
+            auth_time=_authn_event["authn_time"])
 
         # Then encrypt
         if "id_token_encrypted_response_alg" in client_info:
@@ -1110,7 +1111,7 @@ class Provider(AProvider):
 
         authn_event = session.get("authn_event")
         if authn_event:
-            uid = authn_event.uid
+            uid = authn_event["uid"]
         else:
             uid = session['uid']
 

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -388,7 +388,7 @@ class TestProvider(object):
         ae = AuthnEvent("user", "salt")
         _sdb[sid] = {
             "oauth_state": "authz",
-            "authn_event": ae,
+            "authn_event": ae.to_json(),
             "authzreq": authreq.to_json(),
             "client_id": CLIENT_ID,
             "code": access_grant,
@@ -425,7 +425,7 @@ class TestProvider(object):
         ae = AuthnEvent("user", "salt")
         _sdb[sid] = {
             "oauth_state": "authz",
-            "authn_event": ae,
+            "authn_event": ae.to_json(),
             "authzreq": authreq.to_json(),
             "client_id": CLIENT_ID,
             "code": access_grant,
@@ -462,7 +462,7 @@ class TestProvider(object):
         ae = AuthnEvent("user", "salt")
         _sdb[sid] = {
             "oauth_state": "authz",
-            "authn_event": ae,
+            "authn_event": ae.to_json(),
             "authzreq": authreq.to_json(),
             "client_id": CLIENT_ID,
             "code": access_grant,
@@ -498,7 +498,7 @@ class TestProvider(object):
         ae = AuthnEvent("user", "salt")
         _sdb[sid] = {
             "oauth_state": "authz",
-            "authn_event": ae,
+            "authn_event": ae.to_json(),
             "authzreq": authreq.to_json(),
             "client_id": CLIENT_ID,
             "code": access_grant,
@@ -534,7 +534,7 @@ class TestProvider(object):
         access_grant = _sdb.access_token(sid=sid)
         ae = AuthnEvent("user", "salt")
         _sdb[sid] = {
-            "authn_event": ae,
+            "authn_event": ae.to_json(),
             "oauth_state": "authz",
             "authzreq": "",
             "client_id": "client_1",
@@ -1128,7 +1128,7 @@ class TestProvider(object):
         ae = AuthnEvent("user", "salt")
         _sdb[sid] = {
             "oauth_state": "authz",
-            "authn_event": ae,
+            "authn_event": ae.to_json(),
             "authzreq": authreq.to_json(),
             "client_id": CLIENT_ID,
             "code": access_grant,

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -322,7 +322,7 @@ class TestSessionDB(object):
         # given the sub find out whether the authn event is still valid
         sids = self.sdb.get_sids_by_sub(sub)
         ae = self.sdb[sids[0]]["authn_event"]
-        assert ae.valid()
+        assert AuthnEvent(**ae).valid()
 
     def test_do_sub_deterministic(self):
         ae = AuthnEvent("tester", "random_value")

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -411,7 +411,7 @@ class TestSessionDB(object):
         # given the sub find out whether the authn event is still valid
         sids = self.sdb.get_sids_by_sub(sub)
         ae = self.sdb[sids[0]]["authn_event"]
-        assert ae.valid()
+        assert AuthnEvent(**ae).valid()
 
     def test_do_sub_deterministic(self):
         ae = AuthnEvent("tester", "random_value")


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] ~~The documentation has been updated, if necessary.~~

---

This takes a naive approach to solving this issue:

  1. I use the `__dict__` attribute to take the useful data from the AuthnEvent object
  2. Use the dict access syntax for the `session['authn_event']` from there onwards
  3. Rebuild the object with `AuthnEvent(**session['authn_event'])` to use the `valid()` function
    3a. I add new kwargs to the AuthnEvent `__init__`

Another approach would be to use [the jsonpickle](https://jsonpickle.github.io/) package, but I was thinking this was a nice simple approach without the new dependency.

This will close off https://github.com/OpenIDC/pyoidc/issues/360.