### PR TITLE
base URL according to urljoin can only contain one path component.

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1663,7 +1663,7 @@ class Provider(AProvider):
 
         for endp in self.endp:
             # _log_info("# %s, %s" % (endp, endp.name))
-            _provider_info['{}_endpoint'.format(endp.etype)] = urljoin(
+            _provider_info['{}_endpoint'.format(endp.etype)] = '{}/{}'.format(
                 self.baseurl,
                 endp.url)
 


### PR DESCRIPTION
I have use cases where that is not true.
