### PR TITLE
Kmk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on the [KeepAChangeLog] project.
 
 ### Fixed
 - [#369]: The AuthnEvent object is now serialized to JSON for the session.
+- [#373]: Made the standard way the default when dealing with signed JWTs without 'kid'. Added the possibility to override this behavior if necessary.
 
 ### Security
 - [#363]: Fixed IV reuse for CookieDealer class. Replaced the encrypt-then-mac construction with a proper AEAD (AES-SIV). 

--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -502,8 +502,12 @@ class Message(MutableMapping):
                     except KeyError:
                         return
                     else:
-                        for k in kl:
-                            if k.kid in allowed_kids:
+                        if allowed_kids:
+                            for k in kl:
+                                if k.kid in allowed_kids:
+                                    key.append(k)
+                        else:
+                            for k in kl:
                                 key.append(k)
 
     def get_verify_keys(self, keyjar, key, jso, header, jwt, **kwargs):

--- a/tests/test_oauth2_message.py
+++ b/tests/test_oauth2_message.py
@@ -622,34 +622,25 @@ class TestErrorResponse(object):
         with pytest.raises(MissingRequiredAttribute):
             err.to_urlencoded()
 
-
-def test_to_jwt_rsa():
+@pytest.mark.parametrize("keytype,alg",[
+    ('RSA', 'RS256'),
+    ('EC', 'ES256')
+])
+def test_to_jwt(keytype, alg):
     msg = Message(a='foo', b='bar', c='tjoho')
-    _jwt = msg.to_jwt(KEYJAR.get_signing_key('RSA', ''), 'RS256')
-    msg1 = Message().from_jwt(_jwt, KEYJAR.get_signing_key('RSA', ''))
+    _jwt = msg.to_jwt(KEYJAR.get_signing_key(keytype, ''), alg)
+    msg1 = Message().from_jwt(_jwt, KEYJAR.get_signing_key(keytype, ''))
     assert msg1 == msg
 
 
-def test_to_jwt_ec():
+@pytest.mark.parametrize("keytype,alg,enc",[
+    ('RSA', 'RSA1_5', 'A128CBC-HS256'),
+    ('EC', 'ECDH-ES', 'A128GCM'),
+])
+def test_to_jwe(keytype, alg, enc):
     msg = Message(a='foo', b='bar', c='tjoho')
-    _jwt = msg.to_jwt(KEYJAR.get_signing_key('EC', ''), 'ES256')
-    msg1 = Message().from_jwt(_jwt, KEYJAR.get_signing_key('EC', ''))
-    assert msg1 == msg
-
-
-def test_to_jwe_rsa():
-    msg = Message(a='foo', b='bar', c='tjoho')
-    _jwe = msg.to_jwe(KEYJAR.get_encrypt_key('RSA', ''), alg="RSA1_5",
-                      enc="A128CBC-HS256")
-    msg1 = Message().from_jwe(_jwe, KEYJAR.get_encrypt_key('RSA', ''))
-    assert msg1 == msg
-
-
-def test_to_jwe_ec():
-    msg = Message(a='foo', b='bar', c='tjoho')
-    _jwe = msg.to_jwe(KEYJAR.get_encrypt_key('EC', ''), alg="ECDH-ES",
-                      enc="A128GCM")
-    msg1 = Message().from_jwe(_jwe, KEYJAR.get_encrypt_key('EC', ''))
+    _jwe = msg.to_jwe(KEYJAR.get_encrypt_key(keytype, ''), alg=alg, enc=enc)
+    msg1 = Message().from_jwe(_jwe, KEYJAR.get_encrypt_key(keytype, ''))
     assert msg1 == msg
 
 

--- a/tests/test_oauth2_message.py
+++ b/tests/test_oauth2_message.py
@@ -30,8 +30,34 @@ from oic.oauth2.message import TooManyValues
 from oic.oauth2.message import json_deserializer
 from oic.oauth2.message import json_serializer
 from oic.oauth2.message import sp_sep_list_deserializer
+from oic.utils.keyio import build_keyjar
 
 __author__ = 'rohe0002'
+
+keys = [
+    {"type": "RSA", "use": ["sig"]},
+    {"type": "RSA", "use": ["enc"]},
+    {"type": "EC", "crv": "P-256", "use": ["sig"]},
+    {"type": "EC", "crv": "P-256", "use": ["enc"]},
+]
+
+keym = [
+    {"type": "RSA", "use": ["sig"]},
+    {"type": "RSA", "use": ["sig"]},
+    {"type": "RSA", "use": ["sig"]},
+]
+
+KEYJAR = build_keyjar(keys)[1]
+IKEYJAR = build_keyjar(keys)[1]
+IKEYJAR.issuer_keys['issuer'] = IKEYJAR.issuer_keys['']
+del IKEYJAR.issuer_keys['']
+
+KEYJARS = {}
+for iss in ['A','B','C']:
+    _kj = build_keyjar(keym)[1]
+    _kj.issuer_keys[iss] = _kj.issuer_keys['']
+    del _kj.issuer_keys['']
+    KEYJARS[iss] = _kj
 
 
 def url_compare(url1, url2):
@@ -595,3 +621,100 @@ class TestErrorResponse(object):
 
         with pytest.raises(MissingRequiredAttribute):
             err.to_urlencoded()
+
+
+def test_to_jwt_rsa():
+    msg = Message(a='foo', b='bar', c='tjoho')
+    _jwt = msg.to_jwt(KEYJAR.get_signing_key('RSA', ''), 'RS256')
+    msg1 = Message().from_jwt(_jwt, KEYJAR.get_signing_key('RSA', ''))
+    assert msg1 == msg
+
+
+def test_to_jwt_ec():
+    msg = Message(a='foo', b='bar', c='tjoho')
+    _jwt = msg.to_jwt(KEYJAR.get_signing_key('EC', ''), 'ES256')
+    msg1 = Message().from_jwt(_jwt, KEYJAR.get_signing_key('EC', ''))
+    assert msg1 == msg
+
+
+def test_to_jwe_rsa():
+    msg = Message(a='foo', b='bar', c='tjoho')
+    _jwe = msg.to_jwe(KEYJAR.get_encrypt_key('RSA', ''), alg="RSA1_5",
+                      enc="A128CBC-HS256")
+    msg1 = Message().from_jwe(_jwe, KEYJAR.get_encrypt_key('RSA', ''))
+    assert msg1 == msg
+
+
+def test_to_jwe_ec():
+    msg = Message(a='foo', b='bar', c='tjoho')
+    _jwe = msg.to_jwe(KEYJAR.get_encrypt_key('EC', ''), alg="ECDH-ES",
+                      enc="A128GCM")
+    msg1 = Message().from_jwe(_jwe, KEYJAR.get_encrypt_key('EC', ''))
+    assert msg1 == msg
+
+
+def test_get_verify_keys_no_kid_multiple_keys():
+    msg = Message()
+    header = {'alg': 'RS256'}
+    keys = []
+    msg.get_verify_keys(KEYJARS['A'], keys, {'iss': 'A'}, header, {})
+    assert keys == []
+
+
+def test_get_verify_keys_no_kid_single_key():
+    msg = Message()
+    header = {'alg': 'RS256'}
+    keys = []
+    msg.get_verify_keys(IKEYJAR, keys, {'iss': 'issuer'}, header, {})
+    assert len(keys) == 1
+
+
+def test_get_verify_keys_no_kid_multiple_keys_no_kid_issuer():
+    msg = Message()
+    header = {'alg': 'RS256'}
+    keys = []
+
+    a_kids = [k.kid for k in
+              KEYJARS['A'].get_verify_key(owner='A', key_type='RSA')]
+    no_kid_issuer = {'A': a_kids}
+
+    msg.get_verify_keys(KEYJARS['A'], keys, {'iss': 'A'}, header, {},
+                        no_kid_issuer=no_kid_issuer)
+    assert len(keys) == 3
+    assert set([k.kid for k in keys]) == set(a_kids)
+
+
+def test_get_verify_keys_no_kid_multiple_keys_no_kid_issuer_lim():
+    msg = Message()
+    header = {'alg': 'RS256'}
+    keys = []
+
+    a_kids = [k.kid for k in
+              KEYJARS['A'].get_verify_key(owner='A', key_type='RSA')]
+    # get rid of one kid
+    a_kids = a_kids[:-1]
+    no_kid_issuer = {'A': a_kids}
+
+    msg.get_verify_keys(KEYJARS['A'], keys, {'iss': 'A'}, header, {},
+                        no_kid_issuer=no_kid_issuer)
+    assert len(keys) == 2
+    assert set([k.kid for k in keys]) == set(a_kids)
+
+
+def test_get_verify_keys_matching_kid():
+    msg = Message()
+    a_kids = [k.kid for k in
+              KEYJARS['A'].get_verify_key(owner='A', key_type='RSA')]
+    header = {'alg': 'RS256', 'kid': a_kids[0]}
+    keys = []
+    msg.get_verify_keys(KEYJARS['A'], keys, {'iss': 'A'}, header, {})
+    assert len(keys) == 1
+    assert keys[0].kid == a_kids[0]
+
+
+def test_get_verify_keys_no_matching_kid():
+    msg = Message()
+    header = {'alg': 'RS256', 'kid': 'aaaaaaa'}
+    keys = []
+    msg.get_verify_keys(KEYJARS['A'], keys, {'iss': 'A'}, header, {})
+    assert keys == []


### PR DESCRIPTION
Changed the behaviour when a signed JWT is received that contains no kid while the JWKS of the issuer contains more then one key that could have been used.

The default behaviour is that the verification should fail when this happens.
This is what the standard specifies as the expected behaviour.

But if one wants it's now possible to specify issuers that are 'allowed' to not include a kid.
For those issuers the possible set of keys will be checked one at the time.