### PR TITLE
Refactor SessionDB constructor and use secure defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ The format is based on the [KeepAChangeLog] project.
 - [#325]: `oic.oic.claims_match` implementation refactored.
 - [#368]: `oic.oauth2.Client.construct_AccessTokenRequest()` as well as `oic.oic.Client` are now able to perform proper Resource Owner Password Credentials Grant
 - [#374]: Made the to_jwe/from_jwe methods of Message accept list of keys value of parameter keys.
+- [#387]: Refactored the `oic.utils.sdb.SessionDB` constructor API.
 - [#380]: Made cookie_path and cookie_domain configurable via Provider like the cookie_name.
 - [#386]: An exception will now be thrown if a sub claim received from the userinfo endpoint is not the same as a sub claim previously received in an ID Token.
 - [#392]: Made sid creation simpler and faster
-
 
 ### Fixed
 - [#313]: Catch exception correctly
@@ -30,9 +30,10 @@ The format is based on the [KeepAChangeLog] project.
 
 ### Security
 - [#349]: Changed crypto algorithm used by `oic.utils.sdb.Crypt` for token encryption to Fernet. Old stored tokens are incompatible.
-- [#363]: Fixed IV reuse for CookieDealer class. Replaced the encrypt-then-mac construction with a proper AEAD (AES-SIV). 
+- [#363]: Fixed IV reuse for CookieDealer class. Replaced the encrypt-then-mac construction with a proper AEAD (AES-SIV).
 
 [#313]: https://github.com/OpenIDC/pyoidc/issues/313
+[#387]: https://github.com/OpenIDC/pyoidc/pull/387
 [#318]: https://github.com/OpenIDC/pyoidc/pull/318
 [#319]: https://github.com/OpenIDC/pyoidc/pull/319
 [#324]: https://github.com/OpenIDC/pyoidc/pull/324

--- a/oidc_example/op1/claims_provider.py
+++ b/oidc_example/op1/claims_provider.py
@@ -226,7 +226,7 @@ if __name__ == '__main__':
     from cherrypy.wsgiserver import ssl_builtin
 
     from oic.oic.claims_provider import ClaimsServer
-    from oic.utils.sdb import SessionDB
+    from oic.utils.sdb import create_session_db
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', dest='verbose', action='store_true')
@@ -241,7 +241,10 @@ if __name__ == '__main__':
     # in memory session storage
 
     config = json.loads(open(args.config).read())
-    OAS = ClaimsServer(config["issuer"], SessionDB(), cdb, userinfo,
+    sdb = create_session_db(config["issuer"],
+                            config["SESSION_KEY"],
+                            password="changethis")
+    OAS = ClaimsServer(config["issuer"], sdb, cdb, userinfo,
                        verify_client)
 
     if "keys" in config:

--- a/oidc_example/op1/oc_config.py.example
+++ b/oidc_example/op1/oc_config.py.example
@@ -22,6 +22,10 @@ AUTHORIZATION = {
 COOKIENAME= 'pyoic'
 COOKIETTL = 4*60 # 4 hours
 SYM_KEY = "SoLittleTime,Got"
+
+# Encryption Key and HMAC key to 
+SESSION_KEY = "a"*64
+
 SERVER_CERT = "certs/server.crt"
 SERVER_KEY = "certs/server.key"
 #CERT_CHAIN="certs/chain.pem"

--- a/oidc_example/op1/oc_server.py
+++ b/oidc_example/op1/oc_server.py
@@ -481,7 +481,8 @@ if __name__ == '__main__':
     #from cherrypy.wsgiserver import ssl_builtin
     from cherrypy.wsgiserver import ssl_pyopenssl
 
-    from oic.utils.sdb import SessionDB
+    from oic import rndstr
+    from oic.utils.sdb import create_session_db
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', dest='verbose', action='store_true')
@@ -532,18 +533,23 @@ if __name__ == '__main__':
     else:
         kwargs = {"verify_ssl": True}
 
+    # In-Memory SessionDB issuing DefaultTokens
+    sdb = create_session_db(config.baseurl,
+                            secret=rndstr(32),
+                            password=rndstr(32))
+
     if args.test:
         URLS.append((r'tracelog', trace_log))
-        OAS = TestProvider(config.issuer, SessionDB(config.baseurl), cdb, ac,
+        OAS = TestProvider(config.issuer, sdb, cdb, ac,
                            None, authz, config.SYM_KEY)
     elif args.XpressConnect:
         from XpressConnect import XpressConnectProvider
 
-        OAS = XpressConnectProvider(config.issuer, SessionDB(config.baseurl),
+        OAS = XpressConnectProvider(config.issuer, sdb,
                                     cdb, ac, None, authz, verify_client,
                                     config.SYM_KEY)
     else:
-        OAS = Provider(config.issuer, SessionDB(config.baseurl), cdb, ac, None,
+        OAS = Provider(config.issuer, sdb, cdb, ac, None,
                        authz, verify_client, config.SYM_KEY, **kwargs)
 
 

--- a/oidc_example/op2/server.py
+++ b/oidc_example/op2/server.py
@@ -233,7 +233,7 @@ class Application(object):
 
     # noinspection PyUnusedLocal
     def authorization(self, environ, start_response):
-        return wsgi_wrapper(environ, start_response, 
+        return wsgi_wrapper(environ, start_response,
                             self.oas.authorization_endpoint, logger=logger)
 
     # noinspection PyUnusedLocal
@@ -367,7 +367,8 @@ if __name__ == '__main__':
     from cherrypy import wsgiserver
     from cherrypy.wsgiserver.ssl_builtin import BuiltinSSLAdapter
 
-    from oic.utils.sdb import SessionDB
+    from oic import rndstr
+    from oic.utils.sdb import create_session_db
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', dest='verbose', action='store_true')
@@ -545,7 +546,12 @@ if __name__ == '__main__':
     else:
         pass
 
-    OAS = Provider(_issuer, SessionDB(_issuer), cdb, ac, None,
+    # In-Memory non persistent SessionDB
+    sdb = create_session_db(_issuer,
+                            secret=rndstr(32),
+                            password=rndstr(32))
+
+    OAS = Provider(_issuer, sdb, cdb, ac, None,
                    authz, verify_client, config.SYM_KEY, **kwargs)
     OAS.baseurl = _issuer
 

--- a/oidc_example/op3/server.py
+++ b/oidc_example/op3/server.py
@@ -12,6 +12,8 @@ import argparse
 import importlib
 from mako.lookup import TemplateLookup
 
+from oic import rndstr
+
 from oic.oic.provider import AuthorizationEndpoint
 from oic.oic.provider import EndSessionEndpoint
 from oic.oic.provider import Provider
@@ -35,7 +37,7 @@ from oic.utils.webfinger import WebFinger
 from cherrypy import wsgiserver
 from cherrypy.wsgiserver.ssl_builtin import BuiltinSSLAdapter
 
-from oic.utils.sdb import SessionDB
+from oic.utils.sdb import create_session_db
 
 
 
@@ -368,9 +370,14 @@ if __name__ == '__main__':
     authz = AuthzHandling()
     clientDB = shelve_wrapper.open(config.CLIENTDB)
 
+    # In-Memory non-persistent SessionDB issuing DefaultTokens
+    sessionDB = create_session_db(config.ISSUER,
+                                  secret=rndstr(32),
+                                  password=rndstr(32))
+
     provider = Provider(
         name=config.ISSUER,                            # name
-        sdb=SessionDB(config.ISSUER),                  # session database.
+        sdb=sessionDB,                                 # session database.
         cdb=clientDB,                                  # client database
         authn_broker=authnBroker,                      # authn broker
         userinfo=None,                                 # user information

--- a/oidc_example/simple_op/src/provider/server/server.py
+++ b/oidc_example/simple_op/src/provider/server/server.py
@@ -33,7 +33,7 @@ from oic.utils.http_util import SeeOther
 from oic.utils.http_util import get_or_post
 from oic.utils.http_util import get_post
 from oic.utils.keyio import keyjar_init
-from oic.utils.sdb import SessionDB
+from oic.utils.sdb import create_session_db
 from oic.utils.userinfo import UserInfo
 from oic.utils.webfinger import OIC_ISSUER
 from oic.utils.webfinger import WebFinger
@@ -199,7 +199,9 @@ def main():
     userinfo = UserInfo(i)
 
     client_db = {}
-    provider = Provider(issuer, SessionDB(issuer), client_db, authn_broker,
+    session_db = create_session_db(issuer,
+                                   secret=rndstr(32), password=rndstr(32))
+    provider = Provider(issuer, session_db, client_db, authn_broker,
                         userinfo, AuthzHandling(), verify_client, None)
     provider.baseurl = issuer
     provider.symkey = rndstr(16)

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -340,13 +340,25 @@ class DictRefreshDB(RefreshDB):
         self._db.pop(token)
 
 
-def create_session_db(base_url,
-                      secret,
-                      password,
-                      db=None,
-                      token_expires_in=3600,
-                      grant_expires_in=600,
+def create_session_db(base_url, secret, password, db=None,
+                      token_expires_in=3600, grant_expires_in=600,
                       refresh_token_expires_in=86400):
+    """
+    Convenience wrapper for SessionDB construction
+
+    Using this you can create a very basic non persistant
+    session database that issues opaque DefaultTokens.
+
+    :param base_url: Same as base_url parameter of `SessionDB`.
+    :param secret: Secret to pass to `DefaultToken` class.
+    :param password: Secret key to pass to `DefaultToken` class.
+    :param db: Storage for the session data, usually a dict.
+    :param token_expires_in: Expiry time for access tokens in seconds.
+    :param grant_expires_in: Expiry time for access codes in seconds.
+    :param refresh_token_expires_in: Expiry time for refresh tokens.
+
+    :return: A constructed `SessionDB` object.
+    """
 
     code_factory = DefaultToken(secret, password, typ='A',
                                 lifetime=grant_expires_in)
@@ -359,7 +371,9 @@ def create_session_db(base_url,
         refresh_db=None,
         code_factory=code_factory,
         token_factory=token_factory,
-        refresh_token_factory=None)
+        refresh_token_expires_in=refresh_token_expires_in,
+        refresh_token_factory=None,
+    )
 
 
 class SessionDB(object):
@@ -370,6 +384,8 @@ class SessionDB(object):
 
         self.base_url = base_url
         self._db = db
+
+        # TODO: uid2sid should have a persistence option too.
         self.uid2sid = {}
 
         self.token_factory = {
@@ -378,6 +394,9 @@ class SessionDB(object):
         }
 
         self.token_factory_order = ['code', 'access_token']
+
+        # TODO: This should simply be a factory like all the others too,
+        #       even for the default case.
 
         if refresh_token_factory:
             if refresh_db:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def session_db(session_db_factory):
 @pytest.fixture
 def fake_oic_server(session_db_factory):
     from tests.fakeoicsrv import MyFakeOICServer
+
     def fac(name):
         return MyFakeOICServer(name, session_db_factory=session_db_factory)
     return fac
@@ -32,6 +33,7 @@ def fake_oic_server(session_db_factory):
 @pytest.fixture
 def mitm_server(session_db_factory):
     from tests.mitmsrv import MITMServer
+
     def fac(name):
         return MITMServer(name, session_db_factory=session_db_factory)
     return fac

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,42 @@ import pytest
 from oic.oic.provider import Provider
 from oic.utils.authn.client import verify_client
 from oic.utils.authz import AuthzHandling
-from oic.utils.sdb import SessionDB
+from oic.utils.sdb import create_session_db
 
 
 @pytest.fixture
-def provider():
-    issuer = "https://op.foo.com"
+def session_db_factory():
+    def fac(issuer):
+        return create_session_db(issuer,
+                                 secret='supersecret', password='badpassword')
+    return fac
+
+
+@pytest.fixture
+def session_db(session_db_factory):
+    return session_db_factory("https://op.example.com")
+
+
+@pytest.fixture
+def fake_oic_server(session_db_factory):
+    from tests.fakeoicsrv import MyFakeOICServer
+    def fac(name):
+        return MyFakeOICServer(name, session_db_factory=session_db_factory)
+    return fac
+
+
+@pytest.fixture
+def mitm_server(session_db_factory):
+    from tests.mitmsrv import MITMServer
+    def fac(name):
+        return MITMServer(name, session_db_factory=session_db_factory)
+    return fac
+
+
+@pytest.fixture
+def provider(session_db):
+    issuer = "https://op.example.com"
     client_db = {}
-    session_db = SessionDB(issuer),
     verification_function = verify_client
     authz_handler = AuthzHandling()
     symkey = None

--- a/tests/fakeoicsrv.py
+++ b/tests/fakeoicsrv.py
@@ -16,7 +16,6 @@ from oic.oic.message import ProviderConfigurationResponse
 from oic.oic.message import RegistrationResponse
 from oic.oic.message import TokenErrorResponse
 from oic.utils.sdb import AuthnEvent
-from oic.utils.sdb import SessionDB
 from oic.utils.time_util import utc_time_sans_frac
 from oic.utils.webfinger import WebFinger
 
@@ -51,9 +50,9 @@ ENDPOINT = {
 
 
 class MyFakeOICServer(Server):
-    def __init__(self, name=""):
+    def __init__(self, name="", session_db_factory=None):
         Server.__init__(self)
-        self.sdb = SessionDB(name)
+        self.sdb = session_db_factory(name)
         self.name = name
         self.client = {}
         self.registration_expires_in = 3600

--- a/tests/mitmsrv.py
+++ b/tests/mitmsrv.py
@@ -16,7 +16,6 @@ from oic.oic.message import ProviderConfigurationResponse
 from oic.oic.message import RegistrationResponse
 from oic.oic.message import TokenErrorResponse
 from oic.utils.sdb import AuthnEvent
-from oic.utils.sdb import SessionDB
 from oic.utils.time_util import utc_time_sans_frac
 from oic.utils.webfinger import WebFinger
 

--- a/tests/mitmsrv.py
+++ b/tests/mitmsrv.py
@@ -51,9 +51,9 @@ ENDPOINT = {
 
 
 class MITMServer(Server):
-    def __init__(self, name=""):
+    def __init__(self, name="", session_db_factory=None):
         Server.__init__(self)
-        self.sdb = SessionDB(name)
+        self.sdb = session_db_factory(name)
         self.name = name
         self.client = {}
         self.registration_expires_in = 3600

--- a/tests/test_claims_provider.py
+++ b/tests/test_claims_provider.py
@@ -18,7 +18,6 @@ from oic.utils.claims import ClaimsMode
 from oic.utils.keyio import KeyBundle
 from oic.utils.keyio import KeyJar
 from oic.utils.keyio import keybundle_from_local_file
-from oic.utils.sdb import SessionDB
 from oic.utils.userinfo import UserInfo
 
 __author__ = 'rohe0002'
@@ -108,8 +107,8 @@ class TestClaimsServer(object):
     }
 
     @pytest.fixture(autouse=True)
-    def create_claims_server(self, keyjar):
-        self.srv = ClaimsServer("pyoicserv", SessionDB("https://example.com"),
+    def create_claims_server(self, keyjar, session_db):
+        self.srv = ClaimsServer("pyoicserv", session_db,
                                 TestClaimsServer.CDB,
                                 UserInfo(USERDB), verify_client,
                                 keyjar=keyjar,

--- a/tests/test_oauth2_provider.py
+++ b/tests/test_oauth2_provider.py
@@ -15,7 +15,6 @@ from oic.oauth2.message import AuthorizationRequest
 from oic.oauth2.message import AuthorizationResponse
 from oic.oauth2.message import TokenErrorResponse
 from oic.oauth2.provider import Provider
-from oic.utils import sdb
 from oic.utils.authn.authn_context import AuthnBroker
 from oic.utils.authn.client import verify_client
 from oic.utils.authn.user import UserAuthnMethod
@@ -92,19 +91,19 @@ AUTHZ = Implicit()
 
 class TestProvider(object):
     @pytest.fixture(autouse=True)
-    def create_provider(self):
+    def create_provider(self, session_db_factory):
         self.provider = Provider("pyoicserv",
-                                 sdb.SessionDB(ISSUER), CDB,
+                                 session_db_factory(ISSUER), CDB,
                                  AUTHN_BROKER, AUTHZ, verify_client,
                                  baseurl='https://example.com/as')
 
-    def test_init(self):
-        provider = Provider("pyoicserv", sdb.SessionDB(ISSUER),
+    def test_init(self, session_db_factory):
+        provider = Provider("pyoicserv", session_db_factory(ISSUER),
                             CDB,
                             AUTHN_BROKER, AUTHZ, verify_client)
         assert provider
 
-        provider = Provider("pyoicserv", sdb.SessionDB(ISSUER),
+        provider = Provider("pyoicserv", session_db_factory(ISSUER),
                             CDB,
                             AUTHN_BROKER, AUTHZ, verify_client,
                             urlmap={"client1": ["https://example.com/authz"]})

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -10,7 +10,6 @@ import pytest
 from jwkest.jws import alg2keytype
 from jwkest.jws import left_hash
 from jwkest.jwt import JWT
-from tests.fakeoicsrv import MyFakeOICServer
 
 from oic.oauth2.exception import OtherError
 from oic.oic import DEF_SIGN_ALG
@@ -72,7 +71,7 @@ def _eq(l1, l2):
 
 class TestClient(object):
     @pytest.fixture(autouse=True)
-    def create_client(self):
+    def create_client(self, fake_oic_server):
         self.redirect_uri = "http://example.com/redirect"
         self.client = Client(CLIENT_ID, client_authn_method=CLIENT_AUTHN_METHOD)
         self.client.redirect_uris = [self.redirect_uri]
@@ -84,7 +83,7 @@ class TestClient(object):
         self.client.keyjar[""] = KC_RSA
         self.client.behaviour = {
             "request_object_signing_alg": DEF_SIGN_ALG["openid_request_object"]}
-        self.mfos = MyFakeOICServer()
+        self.mfos = fake_oic_server("http://example.com")
         self.mfos.keyjar = KEYJ
         self.client.http_request = self.mfos.http_request
 

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -49,7 +49,6 @@ from oic.utils.keyio import KeyJar
 from oic.utils.keyio import ec_init
 from oic.utils.keyio import keybundle_from_local_file
 from oic.utils.sdb import AuthnEvent
-from oic.utils.sdb import SessionDB
 from oic.utils.time_util import epoch_in_a_while
 from oic.utils.userinfo import UserInfo
 
@@ -176,8 +175,8 @@ USERINFO = UserInfo(USERDB)
 
 class TestProvider(object):
     @pytest.fixture(autouse=True)
-    def create_provider(self):
-        self.provider = Provider(SERVER_INFO["issuer"], SessionDB(SERVER_INFO["issuer"]),
+    def create_provider(self, session_db_factory):
+        self.provider = Provider(SERVER_INFO["issuer"], session_db_factory(SERVER_INFO["issuer"]),
                                  CDB,
                                  AUTHN_BROKER, USERINFO,
                                  AUTHZ, verify_client, SYMKEY, urlmap=URLMAP,
@@ -767,9 +766,9 @@ class TestProvider(object):
 
         assert str(exc_info.value) == "None https redirect_uri not allowed"
 
-    def test_provider_key_setup(self, tmpdir):
+    def test_provider_key_setup(self, tmpdir, session_db_factory):
         path = tmpdir.strpath
-        provider = Provider("pyoicserv", SessionDB(SERVER_INFO["issuer"]), None,
+        provider = Provider("pyoicserv", session_db_factory(SERVER_INFO["issuer"]), None,
                             None, None, None, None, None)
         provider.baseurl = "http://www.example.com"
         provider.key_setup(path, path, sig={"format": "jwk", "alg": "RSA"})
@@ -1060,8 +1059,8 @@ class TestProvider(object):
                 id_token["sub"])  # verify session has been removed
         self._assert_cookies_expired(resp.headers)
 
-    def test_session_state_in_auth_req_for_session_support(self):
-        provider = Provider(SERVER_INFO["issuer"], SessionDB(SERVER_INFO["issuer"]), CDB,
+    def test_session_state_in_auth_req_for_session_support(self, session_db_factory):
+        provider = Provider(SERVER_INFO["issuer"], session_db_factory(SERVER_INFO["issuer"]), CDB,
                             AUTHN_BROKER, USERINFO,
                             AUTHZ, verify_client, SYMKEY, urlmap=URLMAP,
                             keyjar=KEYJAR)

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -14,7 +14,6 @@ from oic.utils.sdb import Crypt
 from oic.utils.sdb import DefaultToken
 from oic.utils.sdb import DictRefreshDB
 from oic.utils.sdb import ExpiredToken
-from oic.utils.sdb import SessionDB
 from oic.utils.sdb import WrongTokenType
 
 __author__ = 'rohe0002'
@@ -99,8 +98,8 @@ class TestToken(object):
 
 class TestSessionDB(object):
     @pytest.fixture(autouse=True)
-    def create_sdb(self):
-        self.sdb = SessionDB("https://example.com/")
+    def create_sdb(self, session_db_factory):
+        self.sdb = session_db_factory("https://example.com/")
 
     def test_create_authz_session(self):
         ae = AuthnEvent("uid", "salt")

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -189,6 +189,9 @@ class TestSessionDB(object):
 
         self.sdb = SessionDB(
             "https://example.com/",
+            db={},
+            code_factory=DefaultToken(
+                'supersecret', 'verybadpassword', typ='A', lifetime=600),
             token_factory=JWTToken('T', keyjar=kj,
                                    lt_pattern={'code': 3600, 'token': 900},
                                    iss='https://example.com/as',

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -10,6 +10,7 @@ from oic.utils.keyio import KeyBundle
 from oic.utils.keyio import KeyJar
 from oic.utils.sdb import AccessCodeUsed
 from oic.utils.sdb import AuthnEvent
+from oic.utils.sdb import DefaultToken
 from oic.utils.sdb import ExpiredToken
 from oic.utils.sdb import SessionDB
 

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -2,7 +2,6 @@ from oic import rndstr
 from oic.extension.client import Client
 from oic.extension.provider import Provider
 from oic.extension.token import JWTToken
-from oic.utils import sdb
 from oic.utils.authn.authn_context import AuthnBroker
 from oic.utils.authn.client import verify_client
 from oic.utils.authn.user import UserAuthnMethod
@@ -52,28 +51,28 @@ def test_pkce_create():
     assert _eq(list(args.keys()), ['code_challenge_method', 'code_challenge'])
 
 
-def test_pkce_verify_256():
+def test_pkce_verify_256(session_db_factory):
     _cli = Client(config={'code_challenge': {'method': 'S256', 'length': 64}})
     args, cv = _cli.add_code_challenge()
 
     authn_broker = AuthnBroker()
     authn_broker.add("UNDEFINED", DummyAuthn(None, "username"))
     _prov = Provider("as",
-                     sdb.SessionDB(SERVER_INFO["issuer"]), CDB,
+                     session_db_factory(SERVER_INFO["issuer"]), CDB,
                      authn_broker, Implicit(), verify_client)
 
     assert _prov.verify_code_challenge(cv, args['code_challenge']) is True
     assert _prov.verify_code_challenge(cv, args['code_challenge'], 'S256') is True
 
 
-def test_pkce_verify_512():
+def test_pkce_verify_512(session_db_factory):
     _cli = Client(config={'code_challenge': {'method': 'S512', 'length': 96}})
     args, cv = _cli.add_code_challenge()
 
     authn_broker = AuthnBroker()
     authn_broker.add("UNDEFINED", DummyAuthn(None, "username"))
     _prov = Provider("as",
-                     sdb.SessionDB(SERVER_INFO["issuer"]), CDB,
+                     session_db_factory(SERVER_INFO["issuer"]), CDB,
                      authn_broker, Implicit(), verify_client)
 
     assert _prov.verify_code_challenge(cv, args['code_challenge'], 'S512') is True

--- a/tests/test_x_dynreg.py
+++ b/tests/test_x_dynreg.py
@@ -90,12 +90,12 @@ class TestProvider(object):
     }
 
     @pytest.fixture(autouse=True)
-    def create_provider(self):
+    def create_provider(self, session_db_factory):
         authn_broker = AuthnBroker()
         authn_broker.add("UNDEFINED", DummyAuthn(None, "username"))
 
         self.provider = Provider("pyoicserv",
-                                 sdb.SessionDB(
+                                 session_db_factory(
                                      TestProvider.SERVER_INFO["issuer"]),
                                  TestProvider.CDB,
                                  authn_broker, Implicit(),

--- a/tests/test_x_dynreg.py
+++ b/tests/test_x_dynreg.py
@@ -9,7 +9,6 @@ from oic.extension.client import RegistrationRequest
 from oic.extension.message import make_software_statement
 from oic.extension.message import unpack_software_statement
 from oic.extension.provider import Provider
-from oic.utils import sdb
 from oic.utils.authn.authn_context import AuthnBroker
 from oic.utils.authn.client import BearerHeader
 from oic.utils.authn.client import ClientSecretBasic

--- a/tests/test_x_provider.py
+++ b/tests/test_x_provider.py
@@ -141,6 +141,9 @@ class TestProvider(object):
 
         _sdb = SessionDB(
             "https://example.com/",
+            db={},
+            code_factory=DefaultToken('supersecret', 'verybadpassword',
+                                      typ='A', lifetime=600),
             token_factory=JWTToken('T', keyjar=kj,
                                    lt_pattern={'code': 3600, 'token': 900},
                                    iss='https://example.com/as',

--- a/tests/test_x_provider.py
+++ b/tests/test_x_provider.py
@@ -24,6 +24,7 @@ from oic.utils.authn.user import UserAuthnMethod
 from oic.utils.authz import Implicit
 from oic.utils.keyio import KeyBundle
 from oic.utils.keyio import KeyJar
+from oic.utils.sdb import DefaultToken
 from oic.utils.sdb import SessionDB
 from oic.utils.sdb import lv_pack
 from oic.utils.sdb import lv_unpack


### PR DESCRIPTION
Refactor the SessionDB constructor to be less overloaded.

Looking into #326 i found the password and secret parameters are only used when a DefaultToken factory is used, so they do not really belong into the SessionDB class, if we externalize the factories. The seed parameter is not used at all.

So i threw out the parameters from the __init__ and wrote a wrapper that is nearly as convenient as the old API for the test/example cases.

This partially fixes https://github.com/OpenIDC/pyoidc/issues/326 as the defaults are gone, but DefaultToken does not raise nice exceptions yet.

This is still work-in-progress, just wanted to get some extra looks and agreement about the direction this goes.

It would still be nice to refactor a bit more (e.g. the RefreshDB/RefreshTokenFactory divide seems unnecessary) and to get to a point where #146 can be fixed, so one can do a persistent SessionDB without too much troubles.