### PR TITLE
Decode and verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ The format is based on the [KeepAChangeLog] project.
 - [#380]: Made cookie_path and cookie_domain configurable via Provider like the cookie_name.
 - [#386]: An exception will now be thrown if a sub claim received from the userinfo endpoint is not the same as a sub claim previously received in an ID Token.
 - [#392]: Made sid creation simpler and faster
-- [#401]: Fixed message decoding and verifying errors.
 
 
 ### Fixed
@@ -27,6 +26,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#362]: Fix bad package settings URL
 - [#369]: The AuthnEvent object is now serialized to JSON for the session.
 - [#373]: Made the standard way the default when dealing with signed JWTs without 'kid'. Added the possibility to override this behavior if necessary.
+- [#401]: Fixed message decoding and verifying errors.
 
 ### Security
 - [#349]: Changed crypto algorithm used by `oic.utils.sdb.Crypt` for token encryption to Fernet. Old stored tokens are incompatible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#380]: Made cookie_path and cookie_domain configurable via Provider like the cookie_name.
 - [#386]: An exception will now be thrown if a sub claim received from the userinfo endpoint is not the same as a sub claim previously received in an ID Token.
 - [#392]: Made sid creation simpler and faster
+- [#401]: Fixed message decoding and verifying errors.
 
 
 ### Fixed

--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ sphinx-autobuild = "*"
 testfixtures = "*"
 tox = "*"
 "-e ." = "*"
+freezegun = "*"
 
 [packages]
 cffi = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4927cb60029aac64afebd65c6deaf3b4ee49d544a0a620dacfc226c27677458b"
+            "sha256": "95e627ebcb0f7571bdbb665476845afd36d03e678d5b96b3f1659d163b720062"
         },
         "requires": {},
         "sources": [
@@ -19,7 +19,7 @@
             "version": "==1.9.0"
         },
         "certifi": {
-            "version": "==2017.4.17"
+            "version": "==2017.7.27.1"
         },
         "cffi": {
             "version": "==1.10.0"
@@ -28,7 +28,7 @@
             "version": "==3.0.4"
         },
         "cryptography": {
-            "version": "==1.9"
+            "version": "==2.0.3"
         },
         "future": {
             "version": "==0.16.0"
@@ -37,7 +37,7 @@
             "version": "==2.5"
         },
         "mako": {
-            "version": "==1.0.6"
+            "version": "==1.0.7"
         },
         "markupsafe": {
             "version": "==1.0"
@@ -55,19 +55,19 @@
             "version": "==2.4.37"
         },
         "pyopenssl": {
-            "version": "==17.1.0"
+            "version": "==17.2.0"
         },
         "requests": {
-            "version": "==2.18.1"
+            "version": "==2.18.3"
         },
         "setuptools": {
-            "version": "==36.0.1"
+            "version": "==36.2.7"
         },
         "six": {
             "version": "==1.10.0"
         },
         "urllib3": {
-            "version": "==1.21.1"
+            "version": "==1.22"
         }
     },
     "develop": {
@@ -82,7 +82,7 @@
             "version": "==2.4.0"
         },
         "certifi": {
-            "version": "==2017.4.17"
+            "version": "==2017.7.27.1"
         },
         "chardet": {
             "version": "==3.0.4"
@@ -94,7 +94,10 @@
             "version": "==4.4.1"
         },
         "docutils": {
-            "version": "==0.13.1"
+            "version": "==0.14"
+        },
+        "freezegun": {
+            "version": "==0.3.9"
         },
         "httpretty": {
             "version": "==0.8.14"
@@ -145,7 +148,7 @@
             "version": "==2.0.0"
         },
         "pyflakes": {
-            "version": "==1.5.0"
+            "version": "==1.6.0"
         },
         "pygments": {
             "version": "==2.2.0"
@@ -154,10 +157,13 @@
             "version": "==7.4.1"
         },
         "pytest": {
-            "version": "==3.1.3"
+            "version": "==3.2.0"
         },
         "pytest-cov": {
             "version": "==2.5.1"
+        },
+        "python-dateutil": {
+            "version": "==2.6.1"
         },
         "pytz": {
             "version": "==2017.2"
@@ -166,13 +172,13 @@
             "version": "==3.12"
         },
         "requests": {
-            "version": "==2.18.1"
+            "version": "==2.18.3"
         },
         "responses": {
-            "version": "==0.5.1"
+            "version": "==0.6.1"
         },
         "setuptools": {
-            "version": "==36.0.1"
+            "version": "==36.2.7"
         },
         "six": {
             "version": "==1.10.0"
@@ -199,7 +205,7 @@
             "version": "==2.7.0"
         },
         "urllib3": {
-            "version": "==1.21.1"
+            "version": "==1.22"
         },
         "virtualenv": {
             "version": "==15.1.0"

--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -431,6 +431,12 @@ class Message(MutableMapping):
         else:
             if val is None:
                 self._dict[skey] = None
+            elif isinstance(val, bool):
+                if vtyp is bool:
+                    self._dict[skey] = val
+                else:
+                    raise ValueError(
+                        '"{}", wrong type of value for "{}"'.format(val, skey))
             elif isinstance(val, vtyp):  # Not necessary to do anything
                 self._dict[skey] = val
             else:
@@ -439,6 +445,15 @@ class Message(MutableMapping):
                         val = _deser(val, sformat="dict")
                     except Exception as exc:
                         raise DecodeError(ERRTXT % (key, exc))
+                elif vtyp == int:
+                    try:
+                        self._dict[skey] = int(val)
+                    except ValueError:
+                        raise ValueError(
+                            '"{}", wrong type of value for "{}"'.format(val,
+                                                                        skey))
+                    else:
+                        return
 
                 if isinstance(val, six.string_types):
                     self._dict[skey] = val

--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -476,11 +476,12 @@ class Message(MutableMapping):
     def _add_key(self, keyjar, issuer, key, key_type='', kid='',
                  no_kid_issuer=None):
 
-        try:
-            logger.debug('Key set summary for {}: {}'.format(
-                issuer, key_summary(keyjar, issuer)))
-        except KeyError:
+        if issuer not in keyjar:
             logger.error('Issuer "{}" not in keyjar'.format(issuer))
+            return
+
+        logger.debug('Key set summary for {}: {}'.format(
+            issuer, key_summary(keyjar, issuer)))
 
         if kid:
             _key = keyjar.get_key_by_kid(kid, issuer)

--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -445,7 +445,7 @@ class Message(MutableMapping):
                         val = _deser(val, sformat="dict")
                     except Exception as exc:
                         raise DecodeError(ERRTXT % (key, exc))
-                elif vtyp == int:
+                elif vtyp is int:
                     try:
                         self._dict[skey] = int(val)
                     except (ValueError, TypeError):

--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -448,7 +448,7 @@ class Message(MutableMapping):
                 elif vtyp == int:
                     try:
                         self._dict[skey] = int(val)
-                    except ValueError:
+                    except (ValueError, TypeError):
                         raise ValueError(
                             '"{}", wrong type of value for "{}"'.format(val,
                                                                         skey))

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -929,7 +929,7 @@ class Client(oauth2.Client):
 
         try:
             resp = self.http_request(path, method, data=body, **h_args)
-        except oauth2.MissingRequiredAttribute:
+        except MissingRequiredAttribute:
             raise
 
         if resp.status_code == 200:

--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -546,10 +546,9 @@ class OpenIDSchema(Message):
                     except ValueError:
                         raise VerificationError("Birthdate format error", self)
 
-        for val in self.values():
-            if val is None:
-                return False
-            
+        if any(val is None for val in self.values()):
+            return False
+
         return True
 
 

--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -546,6 +546,10 @@ class OpenIDSchema(Message):
                     except ValueError:
                         raise VerificationError("Birthdate format error", self)
 
+        for val in self.values():
+            if val is None:
+                return False
+            
         return True
 
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -199,7 +199,7 @@ CAPABILITIES = {
     "subject_types_supported": ["public", "pairwise"],
     "grant_types_supported": [
         "authorization_code", "implicit",
-        "urn:ietf:params:oauth:grant-type:jwt-bearer"],
+        "urn:ietf:params:oauth:grant-type:jwt-bearer", "refresh_token"],
     "claim_types_supported": ["normal", "aggregated", "distributed"],
     "claims_parameter_supported": True,
     "request_parameter_supported": True,

--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -338,7 +338,7 @@ class KeyBundle(object):
         Remove keys that should not be available any more.
         Outdated means that the key was marked as inactive at a time
         that was longer ago then what is given in 'after'.
-        
+
         :param after: The length of time the key will remain in the KeyBundle
             before it should be removed.
         """
@@ -828,7 +828,7 @@ class KeyJar(object):
         """
         Goes through the complete list of issuers and for each of them removes
         outdated keys.
-        Outdated keys are keys that has been marked as inactive at a time that 
+        Outdated keys are keys that has been marked as inactive at a time that
         is longer ago then some set number of seconds.
         The number of seconds a carried in the remove_after parameter.
         """

--- a/tests/test_keyio.py
+++ b/tests/test_keyio.py
@@ -1,8 +1,8 @@
 # pylint: disable=missing-docstring,no-self-use
 import os
+import time
 
 import pytest
-import time
 
 from oic.oauth2.message import MissingSigningKey
 from oic.oic import AuthorizationResponse

--- a/tests/test_keyio.py
+++ b/tests/test_keyio.py
@@ -1,8 +1,11 @@
 # pylint: disable=missing-docstring,no-self-use
 import os
 import time
+from datetime import datetime as dt
+from datetime import timedelta
 
 import pytest
+from freezegun import freeze_time
 
 from oic.oauth2.message import MissingSigningKey
 from oic.oic import AuthorizationResponse
@@ -462,9 +465,11 @@ def test_remove_after():
             if not k.inactive_since:
                 k.inactive_since = _now
 
-    time.sleep(2)
-    # this should remove all the old ones
-    keyjar.remove_outdated()
+    with freeze_time(dt.now()) as frozen:
+        # this should remove all the old ones
+        frozen.tick(delta=timedelta(seconds=2))
+
+        keyjar.remove_outdated()
 
     # The remainder are the new keys
     _new = [k.kid for k in keyjar.get_issuer_keys('') if k.kid]

--- a/tests/test_keyio.py
+++ b/tests/test_keyio.py
@@ -2,6 +2,7 @@
 import os
 
 import pytest
+import time
 
 from oic.oauth2.message import MissingSigningKey
 from oic.oic import AuthorizationResponse
@@ -430,3 +431,44 @@ def test_get_signing_key_use_undefined():
 
     keys = kj.get_signing_key(key_type='rsa', kid='rsa1')
     assert len(keys) == 1
+
+
+KEYDEFS = [
+    {"type": "RSA", "key": '', "use": ["sig"]},
+    {"type": "EC", "crv": "P-256", "use": ["sig"]}
+]
+
+
+def test_remove_after():
+    # initial keyjar
+    keyjar = build_keyjar(KEYDEFS)[1]
+    _old = [k.kid for k in keyjar.get_issuer_keys('') if k.kid]
+    assert len(_old) == 2
+
+    # rotate_keys = create new keys + make the old as inactive
+    keyjar = build_keyjar(KEYDEFS, keyjar=keyjar)[1]
+
+    keyjar.remove_after = 1
+    # None are remove since none are marked as inactive yet
+    keyjar.remove_outdated()
+
+    _interm = [k.kid for k in keyjar.get_issuer_keys('') if k.kid]
+    assert len(_interm) == 4
+
+    # Now mark the keys to be inactivated
+    _now = time.time()
+    for k in keyjar.get_issuer_keys(''):
+        if k.kid in _old:
+            if not k.inactive_since:
+                k.inactive_since = _now
+
+    time.sleep(2)
+    # this should remove all the old ones
+    keyjar.remove_outdated()
+
+    # The remainder are the new keys
+    _new = [k.kid for k in keyjar.get_issuer_keys('') if k.kid]
+    assert len(_new) == 2
+
+    # should not be any overlap between old and new
+    assert set(_new).intersection(set(_old)) == set()

--- a/tests/test_oauth2_message.py
+++ b/tests/test_oauth2_message.py
@@ -135,7 +135,7 @@ class TestMessage(object):
 
     def test_from_json(self):
         jso = '{"req_str": "Fair", "req_str_list": ["spike", "lee"], ' \
-              '"opt_int": [9]}'
+              '"opt_int": 9}'
         item = DummyMessage().deserialize(jso, "json")
 
         assert _eq(item.keys(), ['req_str', 'req_str_list', 'opt_int'])
@@ -144,7 +144,7 @@ class TestMessage(object):
     def test_single_optional(self):
         jso = '{"req_str": "Fair", "req_str_list": ["spike", "lee"], ' \
               '"opt_int": [9, 10]}'
-        with pytest.raises(TooManyValues):
+        with pytest.raises(ValueError):
             DummyMessage().deserialize(jso, "json")
 
     def test_extra_param(self):

--- a/tests/test_oauth2_message.py
+++ b/tests/test_oauth2_message.py
@@ -26,7 +26,6 @@ from oic.oauth2.message import MissingRequiredAttribute
 from oic.oauth2.message import RefreshAccessTokenRequest
 from oic.oauth2.message import ROPCAccessTokenRequest
 from oic.oauth2.message import TokenErrorResponse
-from oic.oauth2.message import TooManyValues
 from oic.oauth2.message import json_deserializer
 from oic.oauth2.message import json_serializer
 from oic.oauth2.message import sp_sep_list_deserializer

--- a/tests/test_oic_message.py
+++ b/tests/test_oic_message.py
@@ -12,7 +12,7 @@ from jwkest.jwk import SYMKey
 
 from oic.oauth2.message import MissingRequiredAttribute
 from oic.oauth2.message import WrongSigningAlgorithm
-from oic.oic.message import AccessTokenResponse
+from oic.oic.message import AccessTokenResponse, OpenIDSchema
 from oic.oic.message import AddressClaim
 from oic.oic.message import AuthorizationRequest
 from oic.oic.message import Claims
@@ -38,6 +38,23 @@ def query_string_compare(query_str1, query_str2):
 
 def _eq(l1, l2):
     return set(l1) == set(l2)
+
+
+def test_openidschema():
+    inp = '{"middle_name":null, "updated_at":"20170328081544", "sub":"abc"}'
+    ois = OpenIDSchema().from_json(inp)
+    assert ois.verify() is False
+
+
+@pytest.mark.parametrize("json_param", [
+    '{"middle_name":"fo", "updated_at":"20170328081544Z", "sub":"abc"}',
+    '{"middle_name":true, "updated_at":"20170328081544", "sub":"abc"}',
+    '{"middle_name":"fo", "updated_at":false, "sub":"abc"}',
+    '{"middle_name":"fo", "updated_at":"20170328081544Z", "sub":true}'
+])
+def test_openidschema_from_json(json_param):
+    with pytest.raises(ValueError):
+        _ = OpenIDSchema().from_json(json_param)
 
 
 def test_claims_deser():

--- a/tests/test_oic_message.py
+++ b/tests/test_oic_message.py
@@ -12,11 +12,12 @@ from jwkest.jwk import SYMKey
 
 from oic.oauth2.message import MissingRequiredAttribute
 from oic.oauth2.message import WrongSigningAlgorithm
-from oic.oic.message import AccessTokenResponse, OpenIDSchema
+from oic.oic.message import AccessTokenResponse
 from oic.oic.message import AddressClaim
 from oic.oic.message import AuthorizationRequest
 from oic.oic.message import Claims
 from oic.oic.message import IdToken
+from oic.oic.message import OpenIDSchema
 from oic.oic.message import ProviderConfigurationResponse
 from oic.oic.message import RegistrationRequest
 from oic.oic.message import RegistrationResponse

--- a/tests/test_oic_message.py
+++ b/tests/test_oic_message.py
@@ -55,7 +55,7 @@ def test_openidschema():
 ])
 def test_openidschema_from_json(json_param):
     with pytest.raises(ValueError):
-        _ = OpenIDSchema().from_json(json_param)
+        OpenIDSchema().from_json(json_param)
 
 
 def test_claims_deser():

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -832,6 +832,7 @@ class TestProvider(object):
 
         assert len(logcap.records) == 0
 
+    @pytest.mark.skip(reason='https://github.com/OpenIDC/pyoidc/issues/402')
     def test_verify_sector_identifier_error(self):
         rr = RegistrationRequest(operation="register", sector_identifier_uri="https://example.com")
         error = ConnectionError('broken connection')


### PR DESCRIPTION
Thanks for contributing to this library! Please include the following check
list in your pull request submission (you can delete this message). If your
changes don't need a change log or documentation update, please ignore this.

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.

---

Working with the OP test tools a misbehaviour in pyoidc became obvious.
In protocol messages the value None on a parameter means that that parameter should just be ignored.
This is not true for Claims and IDToken's. 
None values on parameters in either of these messages should be regarded as errors.

There also where some transformation errors when creating Message instances.
Most notably a non-integer was accepted as a value to a parameter marked as having integer value.

And lastly a problem with Python was discovered.
For some reason isinstance(True, int) == True
So, I had to add some code to work around this.