### PR TITLE
Correctly create error response when wrong response_mode requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ The format is based on the [KeepAChangeLog] project.
 ### Fixed
 - [#405]: Fix generation of endpoint urls
 - [#411]: Empty lists not indexable
+- [#413]: Fix error when wrong response_mode requested
 
 [#405]: https://github.com/OpenIDC/pyoidc/issues/405
+[#413]: https://github.com/OpenIDC/pyoidc/issues/413
 
 ## 0.11.0.0 [2017-07-07]
 

--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -744,7 +744,7 @@ class Provider(object):
                                           redirect_uri=redirect_uri,
                                           headers=headers)
             except InvalidRequest as err:
-                return error("invalid_request", err)
+                return error("invalid_request", str(err))
             else:
                 if resp is not None:
                     return resp

--- a/tests/test_oauth2_provider.py
+++ b/tests/test_oauth2_provider.py
@@ -123,6 +123,20 @@ class TestProvider(object):
         msg = json.loads(resp.message)
         assert msg["error"] == "invalid_request"
 
+    def test_authorization_endpoint_wronge_response_mode(self):
+        bib = {"scope": ["openid"],
+               "state": "id-6da9ca0cc23959f5f33e8becd9b08cae",
+               "redirect_uri": "http://example.com",
+               "response_type": ["code"],
+               "response_mode": "fragment",
+               "client_id": "a1b2c3"}
+
+        arq = AuthorizationRequest(**bib)
+        resp = self.provider.authorization_endpoint(request=arq.to_urlencoded())
+        assert resp.status == "400 Bad Request"
+        msg = json.loads(resp.message)
+        assert msg["error"] == "invalid_request"
+
     def test_authorization_endpoint_faulty_redirect_uri_nwalker(self):
         bib = {"scope": ["openid"],
                "state": "id-6da9ca0cc23959f5f33e8becd9b08cae",


### PR DESCRIPTION
Close #413

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.