### PR TITLE
Fix headers for read_registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ The format is based on the [KeepAChangeLog] project.
 - [#430] Audience of a client assertion is endpoint dependent.
 - [#427] Made matching for response_types order independent for authorization requests
 - [#399] Matching response_types for authz requests is too strict
-- [#xxx] Fixed client.read_registration
+- [#436] Fixed client.read_registration
 
 [#430]: https://github.com/OpenIDC/pyoidc/pull/430
 [#427]: https://github.com/OpenIDC/pyoidc/pull/427
 [#399]: https://github.com/OpenIDC/pyoidc/issues/399
+[#436]: https://github.com/OpenIDC/pyoidc/pull/436
 
 ## 0.12.0 [2017-09-25]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#430] Audience of a client assertion is endpoint dependent.
 - [#427] Made matching for response_types order independent for authorization requests
 - [#399] Matching response_types for authz requests is too strict
+- [#xxx] Fixed client.read_registration
 
 [#430]: https://github.com/OpenIDC/pyoidc/pull/430
 [#427]: https://github.com/OpenIDC/pyoidc/pull/427

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -1255,13 +1255,19 @@ class Client(oauth2.Client):
         return resp
 
     def registration_read(self, url="", registration_access_token=None):
+        """
+        Read the client registration info from the given url
+
+        :raises RegistrationError: If an error happend
+        :return: RegistrationResponse
+        """
         if not url:
             url = self.registration_response["registration_client_uri"]
 
         if not registration_access_token:
             registration_access_token = self.registration_access_token
 
-        headers = [("Authorization", "Bearer %s" % registration_access_token)]
+        headers = {"Authorization", "Bearer %s" % registration_access_token}
         rsp = self.http_request(url, "GET", headers=headers)
 
         return self.handle_registration_info(rsp)


### PR DESCRIPTION
Headers was passed as list instead of as a dictionary.

- [x ] Any changes relevant to users are recorded in the `CHANGELOG.md`.

---
