### PR TITLE
Fix KeyError on provider.read_registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ The format is based on the [KeepAChangeLog] project.
 - [#427] Made matching for response_types order independent for authorization requests
 - [#399] Matching response_types for authz requests is too strict
 - [#436] Fixed client.read_registration
+- [#446] Fixed provider.read_registration
 
 [#430]: https://github.com/OpenIDC/pyoidc/pull/430
 [#427]: https://github.com/OpenIDC/pyoidc/pull/427
 [#399]: https://github.com/OpenIDC/pyoidc/issues/399
 [#436]: https://github.com/OpenIDC/pyoidc/pull/436
 [#443]: https://github.com/OpenIDC/pyoidc/pull/443
+[#446]: https://github.com/OpenIDC/pyoidc/issues/446
 
 ## 0.12.0 [2017-09-25]
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1634,11 +1634,15 @@ class Provider(AProvider):
             return error_response('invalid_request')
         token = authn[len("Bearer "):]
 
-        client_id = self.cdb[token]
+        try:
+            client_id = self.cdb[token]
+        except KeyError:
+            return error_response('invalid_request')
 
         # extra check
         _info = parse_qs(request)
-        assert _info["client_id"][0] == client_id
+        if not _info["client_id"][0] == client_id:
+            return error_response('invalid_request')
 
         logger.debug("Client '%s' reads client info" % client_id)
         args = dict([(k, v) for k, v in self.cdb[client_id].items()

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1637,12 +1637,12 @@ class Provider(AProvider):
         try:
             client_id = self.cdb[token]
         except KeyError:
-            return error_response('invalid_request')
+            return Unauthorized()
 
         # extra check
         _info = parse_qs(request)
         if not _info["client_id"][0] == client_id:
-            return error_response('invalid_request')
+            return Unauthorized()
 
         logger.debug("Client '%s' reads client info" % client_id)
         args = dict([(k, v) for k, v in self.cdb[client_id].items()

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -1077,9 +1077,7 @@ class TestProvider(object):
 
     def test_read_registration_wrong_authn(self):
         resp = self.provider.read_registration('Bearer wrong string', 'request')
-        assert resp.status == '400 Bad Request'
-        assert json.loads(resp.message) == {'error': 'invalid_request',
-                                            'error_description': None}
+        assert resp.status == '401 Unauthorized'
 
     def test_read_registration_wrong_cid(self):
         rr = RegistrationRequest(operation="register",
@@ -1093,9 +1091,7 @@ class TestProvider(object):
         query = '='.join(['client_id', '123456789012'])
         resp = self.provider.read_registration(authn, query)
 
-        assert resp.status == '400 Bad Request'
-        assert json.loads(resp.message) == {'error': 'invalid_request',
-                                            'error_description': None}
+        assert resp.status == '401 Unauthorized'
 
     def test_key_rollover(self):
         provider2 = Provider("FOOP", {}, {}, None, None, None, None, None)

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -1069,8 +1069,30 @@ class TestProvider(object):
 
         assert json.loads(resp.message) == regresp.to_dict()
 
-    def test_read_registration_wrong_authn(self):
+    def test_read_registration_malformed_authn(self):
         resp = self.provider.read_registration('wrong string', 'request')
+        assert resp.status == '400 Bad Request'
+        assert json.loads(resp.message) == {'error': 'invalid_request',
+                                            'error_description': None}
+
+    def test_read_registration_wrong_authn(self):
+        resp = self.provider.read_registration('Bearer wrong string', 'request')
+        assert resp.status == '400 Bad Request'
+        assert json.loads(resp.message) == {'error': 'invalid_request',
+                                            'error_description': None}
+
+    def test_read_registration_wrong_cid(self):
+        rr = RegistrationRequest(operation="register",
+                                 redirect_uris=["http://example.org/new"],
+                                 response_types=["code"])
+        registration_req = rr.to_json()
+        resp = self.provider.registration_endpoint(request=registration_req)
+        regresp = RegistrationResponse().from_json(resp.message)
+
+        authn = ' '.join(['Bearer', regresp['registration_access_token']])
+        query = '='.join(['client_id', '123456789012'])
+        resp = self.provider.read_registration(authn, query)
+
         assert resp.status == '400 Bad Request'
         assert json.loads(resp.message) == {'error': 'invalid_request',
                                             'error_description': None}


### PR DESCRIPTION
Close #446

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
