### PR TITLE
Use Codecov instead of coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,7 @@ install:
   - pip install tox
 
 script:
-  - tox -e coverage-erase,$TOX_ENV
-
-after_success:
-  - tox -e coveralls
+  - tox -e $TOX_ENV
 
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@
 .. image:: https://readthedocs.org/projects/pyoidc/badge/?version=latest
     :target: http://pyoidc.readthedocs.io/en/latest/?badge=latest
 
-.. image:: https://coveralls.io/repos/github/OpenIDC/pyoidc/badge.svg?branch=master
-    :target: https://coveralls.io/github/OpenIDC/pyoidc?branch=master
+.. image:: https://codecov.io/gh/OpenIDC/pyoidc/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/OpenIDC/pyoidc
 
 .. image:: https://landscape.io/github/OpenIDC/pyoidc/master/landscape.svg?style=flat
     :target: https://landscape.io/github/OpenIDC/pyoidc/master

--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,14 @@
 envlist = py{27,34,36},docs,quality
 
 [testenv]
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage.{envname}
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+passenv = CI TRAVIS TRAVIS_*
 commands =
     pipenv install --dev
     pipenv run py.test --cov-report= --cov=oic tests/ -m "not network" {posargs}
-    ; Transform absolute path to relative path for compatibility with coveralls.io and fix 'source not available' error.
-    pipenv run python -c "import os;cov_strip_abspath = open(os.environ['COVERAGE_FILE'], 'r').read().replace('.tox' + os.sep + os.path.relpath('{envsitepackagesdir}', '{toxworkdir}'), 'src');open(os.environ['COVERAGE_FILE'], 'w').write(cov_strip_abspath)"
-deps = pipenv
+    pipenv run codecov
+deps =
+    pipenv
+    codecov
 
 [testenv:docs]
 whitelist_externals = make
@@ -26,32 +25,6 @@ commands =
     pipenv install --dev
     make check-isort
     make check-pylama
-
-[testenv:coveralls]
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage
-passenv =
-    *
-deps =
-    coverage
-    coveralls
-skip_install = true
-commands =
-    coverage combine
-    coveralls
-changedir = {toxinidir}
-
-[testenv:coverage-erase]
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage
-passenv =
-    *
-deps =
-    coverage
-skip_install = true
-commands =
-    coverage erase
-changedir = {toxinidir}
 
 [pep8]
 max-line-length=100


### PR DESCRIPTION
- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
