### PR TITLE
Support for configuration endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on the [KeepAChangeLog] project.
 - [#443] Ability to specify additional supported claims for oic.Provider
 - [#134] Added method kwarg to registration_endpoint that enables the client to read/modify registration
 
+### Changed
+- [#134] ``l_registration_enpoint`` has been deprecated, use ``create_registration`` instead
+
 ### Fixed
 - [#430] Audience of a client assertion is endpoint dependent.
 - [#427] Made matching for response_types order independent for authorization requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on the [KeepAChangeLog] project.
 
 ### Added
 - [#443] Ability to specify additional supported claims for oic.Provider
+- [#134] Added method kwarg to registration_endpoint that enables the client to read/modify registration
 
 ### Fixed
 - [#430] Audience of a client assertion is endpoint dependent.
@@ -25,6 +26,7 @@ The format is based on the [KeepAChangeLog] project.
 [#443]: https://github.com/OpenIDC/pyoidc/pull/443
 [#446]: https://github.com/OpenIDC/pyoidc/issues/446
 [#449]: https://github.com/OpenIDC/pyoidc/issues/449
+[#134]: https://github.com/OpenIDC/pyoidc/issues/134
 
 ## 0.12.0 [2017-09-25]
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -17,6 +17,7 @@ import socket
 import sys
 import time
 import traceback
+import warnings
 from functools import cmp_to_key
 
 import six
@@ -1512,6 +1513,11 @@ class Provider(AProvider):
             args[param] = val
 
     def l_registration_endpoint(self, request, authn=None, **kwargs):
+        warnings.warn('`l_registration_endpoint` is deprecated. Please use `create_registration` instead',
+                      DeprecationWarning)
+        return self.create_registration(request=request, authn=authn, **kwargs)
+
+    def create_registration(self, authn=None, request=None, **kwargs):
         logger.debug("@registration_endpoint: <<%s>>" % sanitize(request))
 
         try:
@@ -1611,7 +1617,7 @@ class Provider(AProvider):
 
     def registration_endpoint(self, request, authn=None, method='POST', **kwargs):
         if method.lower() == 'post':
-            return self.l_registration_endpoint(request, authn, **kwargs)
+            return self.create_registration(authn, request, **kwargs)
         elif method.lower() == 'get':
             return self.read_registration(authn, request, **kwargs)
         elif method.lower() == 'put':
@@ -1669,7 +1675,7 @@ class Provider(AProvider):
         :param request: Query part of the request
         :return: Response with updated client info
         """
-        return error_response('Unsupported operation', descr='Altering of the registration is not supported')
+        return error('Unsupported operation', descr='Altering of the registration is not supported', status_code=403)
 
     def delete_registration(self, authn, request, **kwargs):
         """Method to delete the client info on server side.
@@ -1678,7 +1684,7 @@ class Provider(AProvider):
         :param request: Query part of the request
         :return: Response with updated client info
         """
-        return error_response('Unsupported operation', descr='Deletion of the registration is not supported')
+        return error('Unsupported operation', descr='Deletion of the registration is not supported', status_code=403)
 
     def create_providerinfo(self, pcr_class=ProviderConfigurationResponse,
                             setup=None):

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1609,8 +1609,16 @@ class Provider(AProvider):
 
         return response
 
-    def registration_endpoint(self, request, authn=None, **kwargs):
-        return self.l_registration_endpoint(request, authn, **kwargs)
+    def registration_endpoint(self, request, authn=None, method='POST', **kwargs):
+        if method.lower() == 'post':
+            return self.l_registration_endpoint(request, authn, **kwargs)
+        elif method.lower() == 'get':
+            return self.read_registration(authn, request, **kwargs)
+        elif method.lower() == 'put':
+            return self.alter_registration(authn, request, **kwargs)
+        elif method.lower() == 'delete':
+            return self.delete_registration(authn, request, **kwargs)
+        return error_response('Unsupported method', descr='Unsupported HTTP method')
 
     def read_registration(self, authn, request, **kwargs):
         """
@@ -1653,6 +1661,24 @@ class Provider(AProvider):
 
         return Response(response.to_json(), content="application/json",
                         headers=[("Cache-Control", "no-store")])
+
+    def alter_registration(self, authn, request, **kwargs):
+        """Method to alter the client info on server side.
+
+        :param authn: Authorization HTTP header
+        :param request: Query part of the request
+        :return: Response with updated client info
+        """
+        return error_response('Unsupported operation', descr='Altering of the registration is not supported')
+
+    def delete_registration(self, authn, request, **kwargs):
+        """Method to delete the client info on server side.
+
+        :param authn: Authorization HTTP header
+        :param request: Query part of the request
+        :return: Response with updated client info
+        """
+        return error_response('Unsupported operation', descr='Deletion of the registration is not supported')
 
     def create_providerinfo(self, pcr_class=ProviderConfigurationResponse,
                             setup=None):


### PR DESCRIPTION
Close #134

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
