### PR TITLE
Add no-cache headers to token endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#436] Fixed client.read_registration
 - [#446] Fixed provider.read_registration
 - [#449] Fixed creation of error_response on client registration
+- [#145] Successful token endpoint responses have correct no-cache headers
 
 [#430]: https://github.com/OpenIDC/pyoidc/pull/430
 [#427]: https://github.com/OpenIDC/pyoidc/pull/427
@@ -33,6 +34,7 @@ The format is based on the [KeepAChangeLog] project.
 [#449]: https://github.com/OpenIDC/pyoidc/issues/449
 [#134]: https://github.com/OpenIDC/pyoidc/issues/134
 [#457]: https://github.com/OpenIDC/pyoidc/issues/457
+[#145]: https://github.com/OpenIDC/pyoidc/issues/145
 
 ## 0.12.0 [2017-09-25]
 

--- a/src/oic/extension/provider.py
+++ b/src/oic/extension/provider.py
@@ -51,6 +51,7 @@ from oic.utils.authn.client import AuthnFailure
 from oic.utils.authn.client import UnknownAuthnMethod
 from oic.utils.authn.client import get_client_id
 from oic.utils.authn.client import valid_client_info
+from oic.utils.http_util import OAUTH2_NOCACHE_HEADERS
 from oic.utils.http_util import BadRequest
 from oic.utils.http_util import Forbidden
 from oic.utils.http_util import NoContent
@@ -702,7 +703,7 @@ class Provider(provider.Provider):
 
         logger.debug("AccessTokenResponse: %s" % atr)
 
-        return Response(atr.to_json(), content="application/json")
+        return Response(atr.to_json(), content="application/json", headers=OAUTH2_NOCACHE_HEADERS)
 
     def client_credentials_grant_type(self, areq):
         _at = self.token_handler.get_access_token(areq['client_id'],

--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -43,6 +43,7 @@ from oic.oauth2.message import by_schema
 from oic.utils.authn.user import NoSuchAuthentication
 from oic.utils.authn.user import TamperAllert
 from oic.utils.authn.user import ToOld
+from oic.utils.http_util import OAUTH2_NOCACHE_HEADERS
 from oic.utils.http_util import BadRequest
 from oic.utils.http_util import CookieDealer
 from oic.utils.http_util import Response
@@ -822,7 +823,7 @@ class Provider(object):
 
         logger.debug("AccessTokenResponse: %s" % sanitize(atr))
 
-        return Response(atr.to_json(), content="application/json")
+        return Response(atr.to_json(), content="application/json", headers=OAUTH2_NOCACHE_HEADERS)
 
     def verify_endpoint(self, request="", cookie=None, **kwargs):
         _req = parse_qs(request)

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -71,6 +71,7 @@ from oic.oic.message import RegistrationRequest
 from oic.oic.message import RegistrationResponse
 from oic.oic.message import TokenErrorResponse
 from oic.utils import sort_sign_alg
+from oic.utils.http_util import OAUTH2_NOCACHE_HEADERS
 from oic.utils.http_util import BadRequest
 from oic.utils.http_util import Created
 from oic.utils.http_util import Response
@@ -981,7 +982,7 @@ class Provider(AProvider):
 
         logger.info("access_token_response: %s" % sanitize(atr.to_dict()))
 
-        return Response(atr.to_json(), content="application/json")
+        return Response(atr.to_json(), content="application/json", headers=OAUTH2_NOCACHE_HEADERS)
 
     def _refresh_access_token_endpoint(self, req, **kwargs):
         _sdb = self.sdb
@@ -1017,7 +1018,7 @@ class Provider(AProvider):
 
         logger.info("access_token_response: %s" % sanitize(atr.to_dict()))
 
-        return Response(atr.to_json(), content="application/json")
+        return Response(atr.to_json(), content="application/json", headers=OAUTH2_NOCACHE_HEADERS)
 
     def token_endpoint(self, request="", authn=None, dtype='urlencoded',
                        **kwargs):

--- a/src/oic/utils/http_util.py
+++ b/src/oic/utils/http_util.py
@@ -34,6 +34,11 @@ CORS_HEADERS = [
     ("Access-Control-Allow-Headers", "Authorization")
 ]
 
+OAUTH2_NOCACHE_HEADERS = [
+    ('Pragma', 'no-cache'),
+    ('Cache-Control', 'no-store'),
+]
+
 
 class Response(object):
     _template = None

--- a/tests/test_oauth2_provider.py
+++ b/tests/test_oauth2_provider.py
@@ -276,6 +276,34 @@ class TestProvider(object):
                     'refresh_token': '<REDACTED>'}
         assert _eq(eval(logcap.records[6].msg[21:]), expected)
 
+    def test_token_endpoint_no_cache(self):
+        authreq = AuthorizationRequest(state="state",
+                                       redirect_uri="http://example.com/authz",
+                                       client_id="client1")
+
+        _sdb = self.provider.sdb
+        sid = _sdb.access_token.key(user="sub", areq=authreq)
+        access_grant = _sdb.access_token(sid=sid)
+        _sdb[sid] = {
+            "oauth_state": "authz",
+            "sub": "sub",
+            "authzreq": "",
+            "client_id": "client1",
+            "code": access_grant,
+            "code_used": False,
+            "redirect_uri": "http://example.com/authz"
+        }
+
+        # Construct Access token request
+        areq = AccessTokenRequest(code=access_grant,
+                                  redirect_uri="http://example.com/authz",
+                                  client_id="client1",
+                                  client_secret="hemlighet",
+                                  grant_type='authorization_code')
+        resp = self.provider.token_endpoint(request=areq.to_urlencoded())
+        assert resp.headers == [('Pragma', 'no-cache'), ('Cache-Control', 'no-store'),
+                                ('Content-type', 'application/json')]
+
     def test_token_endpoint_unauth(self):
         authreq = AuthorizationRequest(state="state",
                                        redirect_uri="http://example.com/authz",


### PR DESCRIPTION
Close #145

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
