### PR TITLE
Wrong issuer value in response when iss != baseurl

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -791,7 +791,7 @@ class Provider(AProvider):
         # as per the mix-up draft don't add iss and client_id if they are
         # already in the id_token.
         if 'id_token' not in aresp:
-            aresp['iss'] = self.baseurl
+            aresp['iss'] = self.name
 
         aresp['client_id'] = areq['client_id']
 


### PR DESCRIPTION
I think this is an error. Issuer value should be taken from self.name and not self.baseurl (which might be different).

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
