### PR TITLE
make message about missing registration attribute available to tester

### DIFF
--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -1220,6 +1220,9 @@ class Client(oauth2.Client):
             # Some implementations sends back a 200 with an error message inside
             try:
                 resp.verify()
+            except oauth2.message.MissingRequiredAttribute as err:
+                logger.error(err)
+                raise RegistrationError(err)
             except Exception:
                 resp = ErrorResponse().deserialize(response.text, "json")
                 if resp.verify():

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -266,7 +266,7 @@ class TestClient(object):
         r = Response()
         r.status_code = 201
         r._content = str.encode(json.dumps(msg))
-    
+
         with pytest.raises(RegistrationError) as ex:
             self.client.handle_registration_info(response=r)
             assert 'Missing required attribute \'redirect_uris\'' in str(ex.value)

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -2,6 +2,7 @@
 # from oic.oauth2 import KeyStore
 from future.backports.urllib.parse import urlparse
 
+import json
 import os
 import time
 from collections import Counter
@@ -12,6 +13,7 @@ from jwkest.jws import left_hash
 from jwkest.jwt import JWT
 from requests import Response
 
+from oic.exception import RegistrationError
 from oic.oauth2.exception import OtherError
 from oic.oic import DEF_SIGN_ALG
 from oic.oic import Client
@@ -34,6 +36,7 @@ from oic.oic.message import OpenIDSchema
 from oic.oic.message import RefreshAccessTokenRequest
 from oic.oic.message import RefreshSessionRequest
 from oic.oic.message import RegistrationRequest
+from oic.oic.message import RegistrationResponse
 from oic.oic.message import UserInfoRequest
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from oic.utils.keyio import KeyBundle
@@ -252,6 +255,21 @@ class TestClient(object):
                                  'registration_access_token', 'client_id',
                                  'application_name', 'client_secret',
                                  'response_types'])
+
+    def test_do_registration_response_missing_attribute(self):        
+        # this is lacking the required "redirect_uris" claim in the registration response
+        msg = {
+            "client_id": "s6BhdRkqt3",
+            "client_secret": "ZJYCqe3GGRvdrudKyZS0XhGv_Z45DuKhCUk0gBR1vZk",
+            "token_endpoint_auth_method": "client_secret_basic"
+        }
+        r = Response()
+        r.status_code = 201
+        r._content = str.encode(json.dumps(msg))
+    
+        with pytest.raises(RegistrationError) as ex:
+            self.client.handle_registration_info(response=r)
+            assert 'Missing required attribute \'redirect_uris\'' in str(ex.value)
 
     def test_do_user_info_request_with_access_token_refresh(self):
         args = {"response_type": ["code"],

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -36,7 +36,6 @@ from oic.oic.message import OpenIDSchema
 from oic.oic.message import RefreshAccessTokenRequest
 from oic.oic.message import RefreshSessionRequest
 from oic.oic.message import RegistrationRequest
-from oic.oic.message import RegistrationResponse
 from oic.oic.message import UserInfoRequest
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from oic.utils.keyio import KeyBundle
@@ -256,7 +255,7 @@ class TestClient(object):
                                  'application_name', 'client_secret',
                                  'response_types'])
 
-    def test_do_registration_response_missing_attribute(self):        
+    def test_do_registration_response_missing_attribute(self):
         # this is lacking the required "redirect_uris" claim in the registration response
         msg = {
             "client_id": "s6BhdRkqt3",


### PR DESCRIPTION
see: openid-certification/oidctest#70

this avoids falling into the Exception handler that tries to decode an error registration response error which would trigger another exception that isn't handled

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
