### PR TITLE
Remove ca_certs option and replace it by verify_ssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#134] ``l_registration_enpoint`` has been deprecated, use ``create_registration`` instead
 - [#457] pyldap is now an optional dependency. ``oic.utils.authn.ldapc`` and ``oic.utils.userinfo.ldap_info`` raise
          ``ImportError`` on import if ``pyldap`` is not present
+- [#471] ``ca_certs`` option has been removed, use ``verify_ssl`` instead
 
 ### Fixed
 - [#430] Audience of a client assertion is endpoint dependent.
@@ -40,6 +41,7 @@ The format is based on the [KeepAChangeLog] project.
 [#134]: https://github.com/OpenIDC/pyoidc/issues/134
 [#457]: https://github.com/OpenIDC/pyoidc/issues/457
 [#145]: https://github.com/OpenIDC/pyoidc/issues/145
+[#471]: https://github.com/OpenIDC/pyoidc/issues/471
 
 ## 0.12.0 [2017-09-25]
 

--- a/doc/examples/tls.rst
+++ b/doc/examples/tls.rst
@@ -1,0 +1,56 @@
+TLS configuration
+=================
+
+Both the OP and the RP side make HTTPS based requests
+to various endpoints like webfinger, token endpoints and so on.
+
+So this is used by various classes, a non exhaustive list:
+
+    *  :py:class:`oic.oauth2.Client`
+    *  :py:class:`oic.oic.Client`
+    *  :py:class:`oic.oic.Provider`
+    *  :py:class:`oic.oauth2.Provider`
+    *  :py:class:`oic.utils.keyio.KeyJar`
+    *  :py:class:`oic.utils.keyio.KeyBundle`
+
+Server certificate verification
+-------------------------------
+
+If you want to use the library you should have a working
+TLS certificate verification setup, as OAuth2/OIDC depends
+on TLS for some of its security properties.
+
+If you do nothing and just use all the default settings, certificates
+will be verified using the global settings as documented
+for the python requests library.
+
+.. seealso::
+
+    Requests SSL Cert Verification
+        http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+
+You can customize the setting with the `verify_ssl` option to various classes.
+The semantics follow the definition of the `verify` option for requests, see above.
+
+In short, set `verify_ssl` to:
+
+``True``
+    Verify against the globally configured CA certificates.
+
+``False``
+    Do not verify any certificates. Not recommended.
+
+``path to a ca bundle``
+    Use the given CA bundle for verification.
+
+``path to ca directory``
+    Use the directory as a source for trusted CA certificates.
+
+
+Client side certificates
+------------------------
+
+Some classes allow the configuration of client side TLS certificates
+for mutual authentication. You can configure it with the `client_cert`
+option, which follows the semantics of the request libraries `cert`
+option.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,7 @@ Getting a copy is simple with Pip_:
    examples/rp
    examples/cookbook
    examples/docker
+   examples/tls
 
    contrib/install
    contrib/testing

--- a/oidc_example/op1/oc_server.py
+++ b/oidc_example/op1/oc_server.py
@@ -421,9 +421,9 @@ def application(environ, start_response):
 class TestProvider(Provider):
     #noinspection PyUnusedLocal
     def __init__(self, name, sdb, cdb, function, userdb, urlmap=None,
-                 debug=0, ca_certs="", jwt_keys=None):
+                 debug=0, jwt_keys=None):
         Provider.__init__(self, name, sdb, cdb, function, userdb, urlmap,
-                          ca_certs, jwt_keys)
+                          jwt_keys)
         self.test_mode = True
         self.trace_log = {}
         self.sessions = []

--- a/oidc_example/op3/server.py
+++ b/oidc_example/op3/server.py
@@ -385,12 +385,11 @@ if __name__ == '__main__':
         client_authn=verify_client,                    # client authentication
         symkey=config.SYM_KEY,                         # Used for Symmetric key authentication
         # urlmap = None,                               # ?
-        # ca_certs = "",                               # ?
         # keyjar = None,                               # ?
         # hostname = "",                               # ?
         template_lookup=lookup,                        # ?
         template={"form_post": "form_response.mako"},  # ?
-        # verify_ssl = True,                           # ?
+        # verify_ssl = True,                           # Enable SSL certs
         # capabilities = None,                         # ?
         # schema = OpenIDSchema,                       # ?
         # jwks_uri = '',                               # ?

--- a/oidc_example/rp2/oidc.py
+++ b/oidc_example/rp2/oidc.py
@@ -357,5 +357,5 @@ class OpenIDConnect(object):
         :return:
         """
 
-        wf = WebFinger(httpd=PBase(ca_certs=self.extra["ca_bundle"]))
+        wf = WebFinger(httpd=PBase(verify_ssl=self.extra["ca_bundle"]))
         return wf.discovery_query(resource)

--- a/src/oic/extension/client.py
+++ b/src/oic/extension/client.py
@@ -60,10 +60,10 @@ CC_METHOD = {
 
 
 class Client(oauth2.Client):
-    def __init__(self, client_id=None, ca_certs=None,
+    def __init__(self, client_id=None,
                  client_authn_method=None, keyjar=None, verify_ssl=True,
                  config=None):
-        oauth2.Client.__init__(self, client_id=client_id, ca_certs=ca_certs,
+        oauth2.Client.__init__(self, client_id=client_id,
                                client_authn_method=client_authn_method,
                                keyjar=keyjar, verify_ssl=verify_ssl,
                                config=config)

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -153,28 +153,26 @@ def compact(qsdict):
 class Client(PBase):
     _endpoints = ENDPOINTS
 
-    def __init__(self, client_id=None, ca_certs=None, client_authn_method=None,
+    def __init__(self, client_id=None, client_authn_method=None,
                  keyjar=None, verify_ssl=True, config=None, client_cert=None):
         """
 
         :param client_id: The client identifier
-        :param ca_certs: Certificates used to verify HTTPS certificates
         :param client_authn_method: Methods that this client can use to
             authenticate itself. It's a dictionary with method names as
             keys and method classes as values.
+        :param keyjar: The keyjar for this client.
         :param verify_ssl: Whether the SSL certificate should be verified.
+        :param client_cert: A client certificate to use.
         :return: Client instance
         """
 
-        PBase.__init__(self, ca_certs, verify_ssl=verify_ssl,
-                       client_cert=client_cert, keyjar=keyjar)
+        PBase.__init__(self, verify_ssl=verify_ssl, keyjar=keyjar,
+                       client_cert=client_cert)
 
         self.client_id = client_id
         self.client_authn_method = client_authn_method
-        self.verify_ssl = verify_ssl
-        # self.secret_type = "basic "
 
-        # self.state = None
         self.nonce = None
 
         self.grant = {}
@@ -228,7 +226,6 @@ class Client(PBase):
     client_secret = property(get_client_secret, set_client_secret)
 
     def reset(self):
-        # self.state = None
         self.nonce = None
 
         self.grant = {}
@@ -965,10 +962,9 @@ class Client(PBase):
 
 
 class Server(PBase):
-    def __init__(self, keyjar=None, ca_certs=None, verify_ssl=True,
-                 client_cert=None):
-        PBase.__init__(self, keyjar=keyjar, ca_certs=ca_certs,
-                       verify_ssl=verify_ssl, client_cert=client_cert)
+    def __init__(self, keyjar=None, verify_ssl=True, client_cert=None):
+        PBase.__init__(self, verify_ssl=verify_ssl, keyjar=keyjar,
+                       client_cert=client_cert)
 
     @staticmethod
     def parse_url_request(request, url=None, query=None):

--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -154,13 +154,12 @@ class Provider(object):
 
     def __init__(self, name, sdb, cdb, authn_broker, authz, client_authn,
                  symkey=None, urlmap=None, iv=0, default_scope="",
-                 ca_bundle=None, verify_ssl=True, default_acr="",
+                 verify_ssl=True, default_acr="",
                  baseurl='', server_cls=Server, client_cert=None):
         self.name = name
         self.sdb = sdb
         self.cdb = cdb
-        self.server = server_cls(ca_certs=ca_bundle, verify_ssl=verify_ssl,
-                                 client_cert=client_cert)
+        self.server = server_cls(verify_ssl=verify_ssl, client_cert=client_cert)
 
         self.authn_broker = authn_broker
         if authn_broker is None:

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -298,12 +298,12 @@ def claims_match(value, claimspec):
 class Client(oauth2.Client):
     _endpoints = ENDPOINTS
 
-    def __init__(self, client_id=None, ca_certs=None,
+    def __init__(self, client_id=None,
                  client_prefs=None, client_authn_method=None, keyjar=None,
                  verify_ssl=True, config=None, client_cert=None,
                  requests_dir='requests'):
 
-        oauth2.Client.__init__(self, client_id, ca_certs,
+        oauth2.Client.__init__(self, client_id,
                                client_authn_method=client_authn_method,
                                keyjar=keyjar, verify_ssl=verify_ssl,
                                config=config, client_cert=client_cert)
@@ -1460,9 +1460,9 @@ class Client(oauth2.Client):
 
 
 class Server(oauth2.Server):
-    def __init__(self, keyjar=None, ca_certs=None, verify_ssl=True,
+    def __init__(self, keyjar=None, verify_ssl=True,
                  client_cert=None):
-        oauth2.Server.__init__(self, keyjar, ca_certs, verify_ssl,
+        oauth2.Server.__init__(self, keyjar, verify_ssl,
                                client_cert=client_cert)
 
     @staticmethod

--- a/src/oic/oic/claims_provider.py
+++ b/src/oic/oic/claims_provider.py
@@ -67,13 +67,14 @@ class OICCServer(OicServer):
 
 class ClaimsServer(Provider):
     def __init__(self, name, sdb, cdb, userinfo, client_authn, urlmap=None,
-                 ca_certs="", keyjar=None, hostname="", dist_claims_mode=None):
+                 keyjar=None, hostname="", dist_claims_mode=None,
+                 verify_ssl=True):
         Provider.__init__(self, name, sdb, cdb, None, userinfo, None,
-                          client_authn, None, urlmap, ca_certs, keyjar,
-                          hostname)
+                          client_authn, None, urlmap, keyjar, hostname,
+                          verify_ssl=verify_ssl)
 
         if keyjar is None:
-            keyjar = KeyJar(ca_certs)
+            keyjar = KeyJar(verify_ssl=verify_ssl)
 
         for cid, _dic in cdb.items():
             try:
@@ -163,9 +164,9 @@ class ClaimsServer(Provider):
 
 
 class ClaimsClient(Client):
-    def __init__(self, client_id=None, ca_certs=""):
+    def __init__(self, client_id=None, verify_ssl=True):
 
-        Client.__init__(self, client_id, ca_certs)
+        Client.__init__(self, client_id, verify_ssl=verify_ssl)
 
         self.request2endpoint = REQUEST2ENDPOINT.copy()
         self.request2endpoint["UserClaimsRequest"] = "userclaims_endpoint"

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -233,19 +233,18 @@ def inputs(form_args):
 
 class Provider(AProvider):
     def __init__(self, name, sdb, cdb, authn_broker, userinfo, authz,
-                 client_authn, symkey=None, urlmap=None, ca_certs="", keyjar=None,
+                 client_authn, symkey=None, urlmap=None, keyjar=None,
                  hostname="", template_lookup=None, template=None,
                  verify_ssl=True, capabilities=None, schema=OpenIDSchema,
                  jwks_uri='', jwks_name='', baseurl=None, client_cert=None,
                  extra_claims=None):
 
         AProvider.__init__(self, name, sdb, cdb, authn_broker, authz,
-                           client_authn, symkey, urlmap, ca_bundle=ca_certs,
+                           client_authn, symkey, urlmap,
                            verify_ssl=verify_ssl, client_cert=client_cert)
 
         # Should be a OIC Server not an OAuth2 server
-        self.server = Server(keyjar=keyjar, ca_certs=ca_certs,
-                             verify_ssl=verify_ssl)
+        self.server = Server(keyjar=keyjar, verify_ssl=verify_ssl)
         # Same keyjar
         self.keyjar = self.server.keyjar
 

--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -409,17 +409,14 @@ def dump_jwks(kbl, target, private=False):
 class KeyJar(object):
     """ A keyjar contains a number of KeyBundles """
 
-    def __init__(self, ca_certs=None, verify_ssl=True, keybundle_cls=KeyBundle,
+    def __init__(self, verify_ssl=True, keybundle_cls=KeyBundle,
                  remove_after=3600):
         """
-
-        :param ca_certs:
-        :param verify_ssl: Attempting SSL certificate verification
+        :param verify_ssl: Do SSL certificate verification
         :return:
         """
         self.spec2key = {}
         self.issuer_keys = {}
-        self.ca_certs = ca_certs
         self.verify_ssl = verify_ssl
         self.keybundle_cls = keybundle_cls
         self.remove_after = remove_after

--- a/src/oic/utils/rp/__init__.py
+++ b/src/oic/utils/rp/__init__.py
@@ -30,11 +30,11 @@ class OIDCError(Exception):
 
 
 class Client(oic.Client):
-    def __init__(self, client_id=None, ca_certs=None,
+    def __init__(self, client_id=None,
                  client_prefs=None, client_authn_method=None, keyjar=None,
                  verify_ssl=True, behaviour=None, config=None, jwks_uri='',
                  kid=None):
-        oic.Client.__init__(self, client_id, ca_certs, client_prefs,
+        oic.Client.__init__(self, client_id, client_prefs,
                             client_authn_method, keyjar, verify_ssl,
                             config=config)
         if behaviour:

--- a/src/oic/utils/rp/oauth2.py
+++ b/src/oic/utils/rp/oauth2.py
@@ -30,11 +30,11 @@ class OAuth2Error(Exception):
 
 
 class OAuthClient(client.Client):
-    def __init__(self, client_id=None, ca_certs=None,
+    def __init__(self, client_id=None,
                  client_prefs=None, client_authn_method=None, keyjar=None,
                  verify_ssl=True, behaviour=None, jwks_uri='',
                  kid=None):
-        client.Client.__init__(self, client_id, ca_certs, client_authn_method,
+        client.Client.__init__(self, client_id, client_authn_method,
                                keyjar=keyjar, verify_ssl=verify_ssl)
         self.behaviour = behaviour or {}
         self.userinfo_request_method = ''

--- a/tests/test_oauth2_consumer.py
+++ b/tests/test_oauth2_consumer.py
@@ -20,7 +20,7 @@ __author__ = 'rohe0002'
 
 CLIENT_CONFIG = {
     "client_id": "number5",
-    "ca_certs": "/usr/local/etc/oic/ca_certs.txt",
+    "verify_ssl": "/usr/local/etc/oic/ca_certs.txt",
 }
 
 CONSUMER_CONFIG = {


### PR DESCRIPTION
Remove the ca_certs option that was not handled consistently.
Now our verify_ssl option has the same semantics as the requests verify option.

Also added a few words about TLS in the documentation.

This fixes https://github.com/OpenIDC/pyoidc/issues/471

