### PR TITLE
Fix broken test on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#445] Fixed get_client_id
 - [#421] Fixed handling of unicode in sanitize function
 - [#145] Successful token endpoint responses have correct no-cache headers
+- [#352] Fixed broken windows test for ``test_provider_key_setup``. 
 
 [#430]: https://github.com/OpenIDC/pyoidc/pull/430
 [#427]: https://github.com/OpenIDC/pyoidc/pull/427
@@ -42,6 +43,7 @@ The format is based on the [KeepAChangeLog] project.
 [#457]: https://github.com/OpenIDC/pyoidc/issues/457
 [#145]: https://github.com/OpenIDC/pyoidc/issues/145
 [#471]: https://github.com/OpenIDC/pyoidc/issues/471
+[#352]: https://github.com/OpenIDC/pyoidc/issues/352
 
 ## 0.12.0 [2017-09-25]
 

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -908,15 +908,21 @@ class TestProvider(object):
 
     def test_provider_key_setup(self, tmpdir, session_db_factory):
         path = tmpdir.strpath
+
+        # Path is actually just a random name we turn into a subpath of
+        # our current directory, that doesn't work with drive letters on
+        # windows, so we throw them away and add a '.' for a local path.
+        path = "." + os.path.splitdrive(path)[1].replace(os.path.sep, '/')
+
         provider = Provider("pyoicserv", session_db_factory(SERVER_INFO["issuer"]), None,
                             None, None, None, None, None)
         provider.baseurl = "http://www.example.com"
         provider.key_setup(path, path, sig={"format": "jwk", "alg": "RSA"})
 
         keys = provider.keyjar.get_signing_key("RSA")
+
         assert len(keys) == 1
-        assert provider.jwks_uri == "http://www.example.com/{}/jwks".format(
-                path)
+        assert provider.jwks_uri == "http://www.example.com/{}/jwks".format(path)
 
     @pytest.mark.parametrize("uri", [
         "http://example.org/foo",


### PR DESCRIPTION
Fix the test_provider_key_setup test.

The code under test makes bad assumptions about the filesystem layout.

Basically key_setup/key_export only work for a very specific setup where the export dir is inside the web servers root directory.

The test ignored this assumption and just tried to stuff any random tmpdir path there, which does not work.

The fix just adjusts the tempdir path to a local name, that works.

This should kind of fix https://github.com/OpenIDC/pyoidc/issues/352.
