### PR TITLE
do not include client_id in access token requests that use basic auth

### DIFF
--- a/src/oic/utils/authn/client.py
+++ b/src/oic/utils/authn/client.py
@@ -118,14 +118,7 @@ class ClientSecretBasic(ClientAuthnMethod):
         except KeyError:
             pass
 
-        if isinstance(cis, AccessTokenRequest) and cis[
-                'grant_type'] == 'authorization_code':
-            if 'client_id' not in cis:
-                try:
-                    cis['client_id'] = self.cli.client_id
-                except AttributeError:
-                    pass
-        elif (("client_id" not in cis.c_param.keys()) or
+        if (("client_id" not in cis.c_param.keys()) or
                 cis.c_param["client_id"][VREQUIRED]) is False:
             try:
                 del cis["client_id"]

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -196,7 +196,7 @@ class TestClient(object):
             state='stateX', authn_method='client_secret_basic',
             grant_type='authorization_code')
 
-        assert cis['client_id'] == self.client.client_id
+        assert 'client_id' not in cis
 
         args = {
             "code": "code",
@@ -209,7 +209,7 @@ class TestClient(object):
             state='stateX', authn_method='client_secret_basic',
             grant_type='authorization_code')
 
-        assert cis['client_id'] == self.client.client_id
+        assert 'client_id' not in cis
 
     def test_do_check_session_request(self):
         # RSA signing


### PR DESCRIPTION
this reverses https://github.com/OpenIDC/pyoidc/commit/c0e267040c351cf670ff03c1d70361d4ae024ead done because of https://github.com/OpenIDC/pyoidc/pull/235 which incorrectly refers to OAuth RFC section 3.2.1 (which is about unauthenticated clients that MUST send it); also MS confirms that Azure AD does not need it (anymore)

see:
https://github.com/openid-certification/oidctest/issues/61
and:
https://mailarchive.ietf.org/arch/msg/oauth/OPFwxoO0U1ogYtOA54XwEaali6w

although technically allowed, it reduces interoperability and pyoidc should be strict in what it sends

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
