### PR TITLE
get_verify_key can now return inactive sig keys for verification purp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#421] Fixed handling of unicode in sanitize function
 - [#145] Successful token endpoint responses have correct no-cache headers
 - [#352] Fixed broken windows test for ``test_provider_key_setup``. 
+- [#475] ``get_verify_key`` returns inactive ``sig`` keys for verification
 
 [#430]: https://github.com/OpenIDC/pyoidc/pull/430
 [#427]: https://github.com/OpenIDC/pyoidc/pull/427
@@ -44,6 +45,7 @@ The format is based on the [KeepAChangeLog] project.
 [#145]: https://github.com/OpenIDC/pyoidc/issues/145
 [#471]: https://github.com/OpenIDC/pyoidc/issues/471
 [#352]: https://github.com/OpenIDC/pyoidc/issues/352
+[#475]: https://github.com/OpenIDC/pyoidc/issues/475
 
 ## 0.12.0 [2017-09-25]
 

--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -545,6 +545,10 @@ class KeyJar(object):
                         break
                     if not key.use or use == key.use:
                         lst.append(key)
+                        break
+                    # Verification can be performed by both `sig` and `ver` keys
+                    if key_use == 'ver' and key.use in ('sig', 'ver'):
+                        lst.append(key)
 
         # if elliptic curve have to check I have a key of the right curve
         if key_type == "EC" and "alg" in kwargs:


### PR DESCRIPTION
…oses

Fix #475

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
