### PR TITLE
Validate expiration of Token at UserInfo endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#145] Successful token endpoint responses have correct no-cache headers
 - [#352] Fixed broken windows test for ``test_provider_key_setup``. 
 - [#475] ``get_verify_key`` returns inactive ``sig`` keys for verification
+- [#429] An expired token is not possible to use.
 
 [#430]: https://github.com/OpenIDC/pyoidc/pull/430
 [#427]: https://github.com/OpenIDC/pyoidc/pull/427
@@ -50,6 +51,7 @@ The format is based on the [KeepAChangeLog] project.
 [#475]: https://github.com/OpenIDC/pyoidc/issues/475
 [#478]: https://github.com/OpenIDC/pyoidc/issues/478
 [#483]: https://github.com/OpenIDC/pyoidc/pull/483
+[#429]: https://github.com/OpenIDC/pyoidc/issues/424
 
 ## 0.12.0 [2017-09-25]
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1221,6 +1221,9 @@ class Provider(AProvider):
             logger.error('Wrong token type: {}'.format(typ))
             raise FailedAuthentication("Wrong type of token")
 
+        if _sdb.access_token.is_expired():
+            return error(error='invalid_token', descr='Token is expired', status_code=401)
+
         if _sdb.is_revoked(key):
             return error(error="invalid_token", descr="Token is revoked",
                          status_code=401)

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -83,6 +83,7 @@ class Token(object):
         self.type = typ
         self.lifetime = lifetime
         self.args = kwargs
+        self.issued_at = utc_time_sans_frac()
 
     def __call__(self, sid, *args, **kwargs):
         """
@@ -128,7 +129,19 @@ class Token(object):
         raise NotImplementedError()
 
     def expires_at(self):
-        return utc_time_sans_frac() + self.lifetime
+        return self.issued_at + self.lifetime
+
+    def is_expired(self, when=None):
+        """Return if token is still valid."""
+        if when is None:
+            now = utc_time_sans_frac()
+        else:
+            now = when
+        eat = self.expires_at()
+        if now > eat:
+            return True
+        else:
+            return False
 
     def invalidate(self, token):
         pass


### PR DESCRIPTION
Close #424

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
