### PR TITLE
Fix broken import of SystemRandom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,12 +29,8 @@ pyoidc*
 foo.*
 
 # Windows testing stuff
-.pytest_cache/
 .coverage
 .cache/
-appdata/
-users/
-
 
 # Dynamically created doc folders
 doc/_build

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,14 @@ secret/
 pyoidc*
 foo.*
 
+# Windows testing stuff
+.pytest_cache/
+.coverage
+.cache/
+appdata/
+users/
+
+
 # Dynamically created doc folders
 doc/_build
 !tests/data/keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ The format is based on the [KeepAChangeLog] project.
 - [#475] ``get_verify_key`` returns inactive ``sig`` keys for verification
 - [#429] An expired token is not possible to use.
 
+### Security
+- [#486] SystemRandom is not imported correctly, so various secrets get initialized with bad randomness
+
 [#430]: https://github.com/OpenIDC/pyoidc/pull/430
 [#427]: https://github.com/OpenIDC/pyoidc/pull/427
 [#399]: https://github.com/OpenIDC/pyoidc/issues/399
@@ -52,6 +55,7 @@ The format is based on the [KeepAChangeLog] project.
 [#478]: https://github.com/OpenIDC/pyoidc/issues/478
 [#483]: https://github.com/OpenIDC/pyoidc/pull/483
 [#429]: https://github.com/OpenIDC/pyoidc/issues/424
+[#486]: https://github.com/OpenIDC/pyoidc/issues/486
 
 ## 0.12.0 [2017-09-25]
 

--- a/src/oic/__init__.py
+++ b/src/oic/__init__.py
@@ -3,9 +3,22 @@ import string
 
 # Since SystemRandom is not available on all systems
 try:
-    import random.SystemRandom as rnd
+    # Python 3.6+, designed for this usecase
+    from secrets import choice
 except ImportError:
-    import random as rnd
+    import random
+    try:
+        # Python 2.4+ if available on the platform
+        _sysrand = random.SystemRandom()
+        choice = _sysrand.choice
+    except AttributeError:
+        # Fallback, really bad
+        import warnings
+        choice = random.choice
+        warnings.warn(
+            "No good random number generator available on this platform. "
+            "Security tokens will be weak and guessable.",
+            RuntimeWarning)
 
 __author__ = 'Roland Hedberg'
 __version__ = '0.12.0'
@@ -27,7 +40,7 @@ def rndstr(size=16):
     :return: string
     """
     _basech = string.ascii_letters + string.digits
-    return "".join([rnd.choice(_basech) for _ in range(size)])
+    return "".join([choice(_basech) for _ in range(size)])
 
 
 BASECH = string.ascii_letters + string.digits + '-._~'
@@ -36,10 +49,10 @@ BASECH = string.ascii_letters + string.digits + '-._~'
 def unreserved(size=64):
     """
     Returns a string of random ascii characters, digits and unreserved
-    characters
+    characters for use as RFC 7636 code verifiers
 
     :param size: The length of the string
     :return: string
     """
 
-    return "".join([rnd.choice(BASECH) for _ in range(size)])
+    return "".join([choice(BASECH) for _ in range(size)])


### PR DESCRIPTION
This fixes https://github.com/OpenIDC/pyoidc/issues/486 .

This is a pretty bad security issue, as the secrets used to initialize most crypto is created by `rndstr`, so one can probably brute force things with some small effort (e.g. using untwister and some known values).