### PR TITLE
Better fix for token expiry check

### DIFF
--- a/src/oic/extension/token.py
+++ b/src/oic/extension/token.py
@@ -169,6 +169,10 @@ class JWTToken(Token, JWT):
 
         return False
 
+    def expires_at(self, token):
+        info = self.unpack(token)
+        return info['exp']
+
     def valid(self, token):
         info = self.unpack(token)
         return self.is_valid(info)

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1221,8 +1221,9 @@ class Provider(AProvider):
             logger.error('Wrong token type: {}'.format(typ))
             raise FailedAuthentication("Wrong type of token")
 
-        if _sdb.access_token.is_expired():
-            return error(error='invalid_token', descr='Token is expired', status_code=401)
+        if _sdb.access_token.is_expired(token):
+            return error(error='invalid_token', descr='Token is expired',
+                         status_code=401)
 
         if _sdb.is_revoked(key):
             return error(error="invalid_token", descr="Token is revoked",

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -98,21 +98,24 @@ class TestToken(object):
         assert part[1] == sid
 
     def test_expired_fresh(self):
-        _token = DefaultToken('secret', 'password', lifetime=60)
-        assert _token.is_expired() is False
+        factory = DefaultToken('secret', 'password', lifetime=60)
+        token = factory(sid="abc", ttype="T")
+        assert factory.is_expired(token) is False
 
     def test_expired_stale(self):
         initial_datetime = datetime.datetime(2018, 2, 5, 10, 0, 0, 0)
         final_datetime = datetime.datetime(2018, 2, 5, 10, 1, 0, 0)
+        factory = DefaultToken('secret', 'password', lifetime=2)
         with freeze_time(initial_datetime) as frozen:
-            _token = DefaultToken('secret', 'password', lifetime=2)
+            token = factory(sid="abc", ttype="T")
             frozen.move_to(final_datetime)
-            assert _token.is_expired() is True
+            assert factory.is_expired(token) is True
 
     def test_expired_when(self):
-        _token = DefaultToken('secret', 'password', lifetime=2)
+        factory = DefaultToken('secret', 'password', lifetime=2)
+        token = factory(sid="abc", ttype="T")
         when = time.time() + 5  # 5 seconds from now
-        assert _token.is_expired(when=when) is True
+        assert factory.is_expired(token, when=when) is True
 
 
 class TestSessionDB(object):


### PR DESCRIPTION
Encoded the issued at timestamp in the DefaultToken, so we can check it later.

The specific factories are responsible for checking the tokens they issued.

This fixes the broken tests introduced with PR #482.

Old DefaultToken issued tokens will need to be reissued, JWTTokens stay valid with this change. But due to the problems with randomness it is a good idea to re-issue all tokens anyway.
