### PR TITLE
Fix endpoints usage in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#352] Fixed broken windows test for ``test_provider_key_setup``. 
 - [#475] ``get_verify_key`` returns inactive ``sig`` keys for verification
 - [#429] An expired token is not possible to use.
+- [#370] Use oic.oic.Provider.endp instead of dynamic provider.endpoints in examples
 
 ### Security
 - [#486] SystemRandom is not imported correctly, so various secrets get initialized with bad randomness
@@ -56,6 +57,7 @@ The format is based on the [KeepAChangeLog] project.
 [#483]: https://github.com/OpenIDC/pyoidc/pull/483
 [#429]: https://github.com/OpenIDC/pyoidc/issues/424
 [#486]: https://github.com/OpenIDC/pyoidc/issues/486
+[#370]: https://github.com/OpenIDC/pyoidc/issues/370
 
 ## 0.12.0 [2017-09-25]
 

--- a/oidc_example/op1/claims_provider.py
+++ b/oidc_example/op1/claims_provider.py
@@ -260,7 +260,7 @@ if __name__ == '__main__':
     if args.debug:
         OAS.debug = True
 
-    OAS.endpoints = ENDPOINTS
+    OAS.endp = ENDPOINTS
     if args.port == 80:
         OAS.baseurl = config["baseurl"]
     else:

--- a/oidc_example/op1/oc_server.py
+++ b/oidc_example/op1/oc_server.py
@@ -585,7 +585,7 @@ if __name__ == '__main__':
         endpoints = ENDPOINTS
 
     add_endpoints(endpoints)
-    OAS.endpoints = endpoints
+    OAS.endp = endpoints
 
     if args.port == 80:
         OAS.baseurl = config.baseurl

--- a/oidc_example/op2/server.py
+++ b/oidc_example/op2/server.py
@@ -164,7 +164,7 @@ class Application(object):
             EndSessionEndpoint(self.endsession),
         ]
 
-        self.oas.endpoints = self.endpoints
+        self.oas.endp = self.endpoints
         self.urls = urls
         self.urls.extend([
             (r'^.well-known/openid-configuration', self.op_info),

--- a/oidc_example/op3/server.py
+++ b/oidc_example/op3/server.py
@@ -126,7 +126,7 @@ class Application(object):
             EndSessionEndpoint(self.endsession),
         ]
 
-        self.provider.endpoints = self.endpoints
+        self.provider.endp = self.endpoints
         self.urls = urls
         self.urls.extend([
             (r'^.well-known/openid-configuration', self.op_info),

--- a/oidc_example/simple_op/src/provider/server/server.py
+++ b/oidc_example/simple_op/src/provider/server/server.py
@@ -135,6 +135,7 @@ def setup_endpoints(provider):
             pyoidcMiddleware(provider.endsession_endpoint))
     ]
 
+    provider.endp = endpoints
     for ep in endpoints:
         app_routing["/{}".format(ep.etype)] = ep
 


### PR DESCRIPTION
The examples overwrote the endpoints method, instead of setting the endp member variable.

This fixes the Issue #370.

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
