### PR TITLE
Respect passed in status_code in oic.oauth2.error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#475] ``get_verify_key`` returns inactive ``sig`` keys for verification
 - [#429] An expired token is not possible to use.
 - [#370] Use oic.oic.Provider.endp instead of dynamic provider.endpoints in examples
+- [#466] ``oic.oauth2.error`` now uses received ``status_code``
 
 ### Security
 - [#486] SystemRandom is not imported correctly, so various secrets get initialized with bad randomness
@@ -58,6 +59,7 @@ The format is based on the [KeepAChangeLog] project.
 [#429]: https://github.com/OpenIDC/pyoidc/issues/424
 [#486]: https://github.com/OpenIDC/pyoidc/issues/486
 [#370]: https://github.com/OpenIDC/pyoidc/issues/370
+[#466]: https://github.com/OpenIDC/pyoidc/issues/466
 
 ## 0.12.0 [2017-09-25]
 

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -94,7 +94,7 @@ def none_response(**kwargs):
 
 
 def error(error, descr=None, status_code=400):
-    stat_txt = R2C[400]._status
+    stat_txt = R2C.get(status_code, R2C[400])._status
     return error_response(error=error, descr=descr, status=stat_txt)
 
 

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -13,6 +13,7 @@ from oic.oauth2 import Client
 from oic.oauth2 import Grant
 from oic.oauth2 import Server
 from oic.oauth2 import Token
+from oic.oauth2 import error
 from oic.oauth2.exception import GrantError
 from oic.oauth2.exception import MissingEndpoint
 from oic.oauth2.exception import ResponseError
@@ -61,6 +62,20 @@ def query_string_compare(query_str1, query_str2):
 
 def _eq(l1, l2):
     return set(l1) == set(l2)
+
+
+class TestError(object):
+    """Tests for error class."""
+
+    def test_custom_status(self):
+        response = error('Really bad error', status_code=500)
+        assert response.status == '500 Internal Service Error'
+        assert json.loads(response.message) == {'error_description': None, 'error': 'Really bad error'}
+
+    def test_missing_status(self):
+        response = error('Strange error', status_code=888)
+        assert response.status == '400 Bad Request'
+        assert json.loads(response.message) == {'error_description': None, 'error': 'Strange error'}
 
 
 class TestClient(object):


### PR DESCRIPTION
Close #466

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
