### PR TITLE
grant_types should follow response_types in a client registration req…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on the [KeepAChangeLog] project.
 ## 0.13.0 [Unreleased]
 
 ### Added
+- [#493] grant_types specification should follow the response_types sprecification in a client registration request.
 - [#469] Allow endpoints to have query parts
 - [#443] Ability to specify additional supported claims for oic.Provider
 - [#134] Added method kwarg to registration_endpoint that enables the client to read/modify registration
@@ -45,6 +46,7 @@ The format is based on the [KeepAChangeLog] project.
 ### Security
 - [#486] SystemRandom is not imported correctly, so various secrets get initialized with bad randomness
 
+[#493]: https://github.com/OpenIDC/pyoidc/pull/493
 [#430]: https://github.com/OpenIDC/pyoidc/pull/430
 [#427]: https://github.com/OpenIDC/pyoidc/pull/427
 [#399]: https://github.com/OpenIDC/pyoidc/issues/399

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on the [KeepAChangeLog] project.
 ## 0.13.0 [Unreleased]
 
 ### Added
-- [#493] grant_types specification should follow the response_types sprecification in a client registration request.
+- [#493] grant_types specification should follow the response_types specification in a client registration request.
 - [#469] Allow endpoints to have query parts
 - [#443] Ability to specify additional supported claims for oic.Provider
 - [#134] Added method kwarg to registration_endpoint that enables the client to read/modify registration

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -1345,7 +1345,7 @@ class Client(oauth2.Client):
         except KeyError:
             pass
 
-        if 'response_types' in req :
+        if 'response_types' in req:
             req['grant_types'] = response_types_to_grant_types(
                 req['response_types'])
 

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -1345,11 +1345,9 @@ class Client(oauth2.Client):
         except KeyError:
             pass
 
-        try:
+        if 'response_types' in req :
             req['grant_types'] = response_types_to_grant_types(
                 req['response_types'])
-        except KeyError:
-            pass
 
         return req
 

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -257,6 +257,32 @@ PARAMMAP = {
     "enc": "%s_encrypted_response_enc",
 }
 
+rt2gt = {
+    'code': ['authorization_code'],
+    'id_token': ['implicit'],
+    'id_token token': ['implicit'],
+    'code id_token': ['authorization_code', 'implicit'],
+    'code token': ['authorization_code', 'implicit'],
+    'code id_token token': ['authorization_code', 'implicit']
+}
+
+
+def response_types_to_grant_types(response_types):
+    _res = set()
+
+    for response_type in response_types:
+        _rt = response_type.split(' ')
+        _rt.sort()
+        try:
+            _gt = rt2gt[" ".join(_rt)]
+        except KeyError:
+            raise ValueError(
+                'No such response type combination: {}'.format(response_types))
+        else:
+            _res.update(set(_gt))
+
+    return list(_res)
+
 
 def claims_match(value, claimspec):
     """
@@ -1316,6 +1342,12 @@ class Client(oauth2.Client):
             if self.provider_info['require_request_uri_registration'] is True:
                 req['request_uris'] = self.generate_request_uris(
                     self.requests_dir)
+        except KeyError:
+            pass
+
+        try:
+            req['grant_types'] = response_types_to_grant_types(
+                req['response_types'])
         except KeyError:
             pass
 

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -84,6 +84,7 @@ def test_response_types_to_grant_types():
         response_types_to_grant_types(req_args)) == {'authorization_code',
                                                      'implicit'}
 
+
 def test_clean_response():
     atr = AccessTokenResponse(access_token="access_token",
                               token_type="bearer", expires_in=600,

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -11,6 +11,7 @@ from jwkest.jwk import SYMKey
 from oic.oauth2.message import MissingSigningKey
 from oic.oic import DEF_SIGN_ALG
 from oic.oic import Server
+from oic.oic import response_types_to_grant_types
 from oic.oic.consumer import IGNORE
 from oic.oic.consumer import Consumer
 from oic.oic.consumer import clean_response
@@ -69,6 +70,19 @@ CONFIG = {
 def _eq(l1, l2):
     return set(l1) == set(l2)
 
+
+def test_response_types_to_grant_types():
+    req_args = ['code']
+    assert set(
+        response_types_to_grant_types(req_args)) == {'authorization_code'}
+    req_args = ['code', 'code id_token']
+    assert set(
+        response_types_to_grant_types(req_args)) == {'authorization_code',
+                                                     'implicit'}
+    req_args = ['code', 'id_token code', 'code token id_token']
+    assert set(
+        response_types_to_grant_types(req_args)) == {'authorization_code',
+                                                     'implicit'}
 
 def test_clean_response():
     atr = AccessTokenResponse(access_token="access_token",

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -84,6 +84,9 @@ def test_response_types_to_grant_types():
         response_types_to_grant_types(req_args)) == {'authorization_code',
                                                      'implicit'}
 
+    with pytest.raises(ValueError):
+        response_types_to_grant_types(['foobar openid'])
+
 
 def test_clean_response():
     atr = AccessTokenResponse(access_token="access_token",


### PR DESCRIPTION
grant_types should follow response_types in a client registration request

- [x ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---