### PR TITLE
Fix arg for WSGI start_response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on the [KeepAChangeLog] project.
 
 [KeepAChangeLog]: http://keepachangelog.com/
 
+
+## 0.13.1 [Unreleased]
+
+### Fixed
+- [#515]: Fix arguments to WSGI start_response
+
+[#515]: https://github.com/OpenIDC/pyoidc/issues/515
+
 ## 0.13.0 [2018-02-19]
 
 ### Added

--- a/src/oic/utils/http_util.py
+++ b/src/oic/utils/http_util.py
@@ -15,6 +15,7 @@ from jwkest import safe_str_cmp
 from six import PY2
 from six import binary_type
 from six import text_type
+from six.moves import http_client
 
 from oic import rndstr
 from oic.exception import ImproperlyConfigured
@@ -80,7 +81,8 @@ class Response(object):
         return R2C[self.status_code]._status
 
     def __call__(self, environ, start_response, **kwargs):
-        start_response(self.status_code, self.headers)
+        name = http_client.responses.get(self.status_code, 'UNKNOWN')
+        start_response("{} {}".format(self.status_code, name), self.headers)
         return self.response(self.message, **kwargs)
 
     def _response(self, message="", **argv):

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -26,7 +26,7 @@ class TestResponse(object):
         message = "foo bar"
 
         def start_response(status, headers):
-            assert status == 200
+            assert status == '200 OK'
             assert response_header in headers
 
         resp = Response(message, headers=[response_header])
@@ -39,7 +39,7 @@ class TestResponse(object):
         message = '<script>alert("hi");</script>'
 
         def start_response(status, headers):
-            assert status == 200
+            assert status == '200 OK'
             assert response_header in headers
 
         resp = Response(message=message, headers=[response_header], template=template)


### PR DESCRIPTION
Close #515

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
