### PR TITLE
Fix responses from IntrospectionEndpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on the [KeepAChangeLog] project.
 ### Fixed
 - [#503] Fix error on UserInfo endpoint for removed clients
 - [#508] JWT now uses verify keys for JWT verification
+- [#502] IntrospectionEndpoint now returns False if it encounters any error as per specs
 
 ### Removed
 - [#494] Methods and functions deprecated in previous releases have been removed
@@ -25,6 +26,7 @@ The format is based on the [KeepAChangeLog] project.
 [#503]: https://github.com/OpenIDC/pyoidc/issues/503
 [#508]: https://github.com/OpenIDC/pyoidc/issues/508
 [#507]: https://github.com/OpenIDC/pyoidc/issues/507
+[#502]: https://github.com/OpenIDC/pyoidc/issues/502
 
 ## 0.13.1 [2018-04-06]
 

--- a/src/oic/extension/provider.py
+++ b/src/oic/extension/provider.py
@@ -826,29 +826,31 @@ class Provider(provider.Provider):
             token_type = req['token_type_hint']
         except KeyError:
             try:
-                _info = self.sdb.token_factory['access_token'].info(
-                    req['token'])
-            except KeyError:
+                _info = self.sdb.token_factory['access_token'].get_info(req['token'])
+            except Exception:
                 try:
-                    _info = self.sdb.token_factory['refresh_token'].get_info(
-                        req['token'])
-                except KeyError:
-                    raise
+                    _info = self.sdb.token_factory['refresh_token'].get_info(req['token'])
+                except Exception:
+                    return self._return_inactive()
                 else:
                     token_type = 'refresh_token'
             else:
                 token_type = 'access_token'
         else:
             try:
-                _info = self.sdb.token_factory[token_type].get_info(
-                    req['token'])
-            except KeyError:
-                raise
+                _info = self.sdb.token_factory[token_type].get_info(req['token'])
+            except Exception:
+                return self._return_inactive()
 
         if not self.token_access(endpoint, client_id, _info):
             return BadRequest()
 
         return client_id, token_type, _info
+
+    @staticmethod
+    def _return_inactive():
+        ir = TokenIntrospectionResponse(active=False)
+        return Response(ir.to_json(), content="application/json")
 
     def revocation_endpoint(self, authn='', request=None, **kwargs):
         """

--- a/tests/test_x_provider.py
+++ b/tests/test_x_provider.py
@@ -340,6 +340,25 @@ class TestProvider(object):
         ti_resp = TokenIntrospectionResponse().deserialize(resp.message, 'json')
         assert ti_resp['active'] is True
 
+    def test_token_introspection_bad_access_token(self):
+        req = TokenIntrospectionRequest(token='access_token',
+                                        client_id="client1",
+                                        client_secret="hemlighet",
+                                        token_type_hint='access_token')
+        resp = self.provider.introspection_endpoint(request=req.to_urlencoded())
+        assert resp
+        ti_resp = TokenIntrospectionResponse().deserialize(resp.message, 'json')
+        assert ti_resp['active'] is False
+
+    def test_token_introspection_bad_token_no_hint(self):
+        req = TokenIntrospectionRequest(token='access_token',
+                                        client_id="client1",
+                                        client_secret="hemlighet")
+        resp = self.provider.introspection_endpoint(request=req.to_urlencoded())
+        assert resp
+        ti_resp = TokenIntrospectionResponse().deserialize(resp.message, 'json')
+        assert ti_resp['active'] is False
+
     def test_token_introspection_missing(self):
         authreq = AuthorizationRequest(state="state",
                                        redirect_uri="http://example.com/authz",


### PR DESCRIPTION
IntrospectionEndpoint should return regular response with active=False
if it cannot verify the activity of the token for any reason.

Close #502

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
