### PR TITLE
Remove replaced tokens on `do_access_token_refresh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on the [KeepAChangeLog] project.
 - [#526] Cleaned up extra claims from UserInfo with distributed claims
 - [#528] Fix faulty redirect_uri with query
 - [#532] Fix userinfo endpoint without auhtn_event in session
+- [#528] Fix faulty redirect_uri with query
+- [#498] Clean up replaced tokens on refresh and add Client.clean_tokens to clean old and replaced tokens
 
 ### Removed
 - [#494] Methods and functions deprecated in previous releases have been removed
@@ -40,6 +42,7 @@ The format is based on the [KeepAChangeLog] project.
 [#526]: https://github.com/OpenIDC/pyoidc/issues/526
 [#528]: https://github.com/OpenIDC/pyoidc/issues/528
 [#532]: https://github.com/OpenIDC/pyoidc/pull/532
+[#498]: https://github.com/OpenIDC/pyoidc/issues/498
 
 ## 0.13.1 [2018-04-06]
 

--- a/src/oic/oauth2/grant.py
+++ b/src/oic/oauth2/grant.py
@@ -131,6 +131,13 @@ class Grant(object):
 
         return token
 
+    def delete_token(self, token):
+        """Remove the specified token if it exists."""
+        try:
+            self.tokens.remove(token)
+        except ValueError:
+            pass
+
     def get_id_token(self):
         if self.id_token:
             if self.id_token["exp"] >= time.time():

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -70,6 +70,28 @@ class TestGrant(object):
 
         assert len(grant.tokens) == 0
 
+    def test_delete_token(self):
+        grant = Grant()
+        grant.update(ATR)
+
+        token = grant.get_token()
+
+        grant.delete_token(token)
+        assert len(grant.tokens) == 0
+
+    def test_delete_unknown(self):
+        grant = Grant()
+        grant.update(ATR)
+
+        atr = AccessTokenResponse(access_token="2YotnFZFEjr1zCsicMWpAA",
+                                  token_type="example",
+                                  refresh_token="tGzv3JOkF0XG5Qx2TlKWIA",
+                                  xscope=["inner", "outer"])
+        token = Token(atr)
+
+        grant.delete_token(token)
+        assert len(grant.tokens) == 1
+
 
 class TestToken(object):
     def test_access_token(self):


### PR DESCRIPTION
Close #498

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
