### PR TITLE
Fix userinfo with missing authn_event in session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on the [KeepAChangeLog] project.
 - [#481] Loading AuthnEvent from session
 - [#492] Do not verify JWT signature on distributed claims
 - [#526] Cleaned up extra claims from UserInfo with distributed claims
-- [#528]: Fix faulty redirect_uri with query
+- [#528] Fix faulty redirect_uri with query
+- [#532] Fix userinfo endpoint without auhtn_event in session
 
 ### Removed
 - [#494] Methods and functions deprecated in previous releases have been removed
@@ -38,6 +39,7 @@ The format is based on the [KeepAChangeLog] project.
 [#432]: https://github.com/OpenIDC/pyoidc/issues/432
 [#526]: https://github.com/OpenIDC/pyoidc/issues/526
 [#528]: https://github.com/OpenIDC/pyoidc/issues/528
+[#532]: https://github.com/OpenIDC/pyoidc/pull/532
 
 ## 0.13.1 [2018-04-06]
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1083,9 +1083,8 @@ class Provider(AProvider):
 
         logger.debug("Session info: %s" % sanitize(session))
 
-        authn_event = AuthnEvent.from_json(session.get("authn_event"))
-        if authn_event:
-            uid = authn_event.uid
+        if "authn_event" in session:
+            uid = AuthnEvent.from_json(session["authn_event"]).uid
         else:
             uid = session['uid']
 


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
This can happen in some cases for offline access if users implement their own Refresh storage. The AuhtnEvent is pointles in this case anyway as it might be already invalid.