### PR TITLE
According to https://tools.ietf.org/html/rfc6749#section-2.3.1 client…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on the [KeepAChangeLog] project.
 ## 0.X.X [Unreleased]
 
 ### Fixed
+- [#534] Fixed a bug in client_secret_basic authentication
 - [#503] Fix error on UserInfo endpoint for removed clients
 - [#508] JWT now uses verify keys for JWT verification
 - [#502] IntrospectionEndpoint now returns False if it encounters any error as per specs
@@ -43,6 +44,7 @@ The format is based on the [KeepAChangeLog] project.
 [#528]: https://github.com/OpenIDC/pyoidc/issues/528
 [#532]: https://github.com/OpenIDC/pyoidc/pull/532
 [#498]: https://github.com/OpenIDC/pyoidc/issues/498
+[#534]: https://github.com/OpenIDC/pyoidc/pull/534
 
 ## 0.13.1 [2018-04-06]
 

--- a/src/oic/utils/authn/client.py
+++ b/src/oic/utils/authn/client.py
@@ -110,8 +110,7 @@ class ClientSecretBasic(ClientAuthnMethod):
             http_args["headers"] = {}
 
         credentials = "{}:{}".format(quote_plus(user), quote_plus(passwd))
-        authz = base64.urlsafe_b64encode(credentials.encode("utf-8")).decode(
-            "utf-8")
+        authz = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
         http_args["headers"]["Authorization"] = "Basic {}".format(authz)
 
         try:

--- a/src/oic/utils/authn/client.py
+++ b/src/oic/utils/authn/client.py
@@ -1,8 +1,9 @@
+from future.backports.urllib.parse import quote_plus
+
 import base64
 import logging
 
 import six
-from future.backports.urllib.parse import quote_plus
 from jwkest import Invalid
 from jwkest import MissingKey
 from jwkest import as_bytes

--- a/src/oic/utils/authn/client.py
+++ b/src/oic/utils/authn/client.py
@@ -2,6 +2,7 @@ import base64
 import logging
 
 import six
+from future.backports.urllib.parse import quote_plus
 from jwkest import Invalid
 from jwkest import MissingKey
 from jwkest import as_bytes
@@ -108,7 +109,7 @@ class ClientSecretBasic(ClientAuthnMethod):
         if "headers" not in http_args:
             http_args["headers"] = {}
 
-        credentials = "{}:{}".format(user, passwd)
+        credentials = "{}:{}".format(quote_plus(user), quote_plus(passwd))
         authz = base64.urlsafe_b64encode(credentials.encode("utf-8")).decode(
             "utf-8")
         http_args["headers"]["Authorization"] = "Basic {}".format(authz)

--- a/src/oic/utils/authn/user.py
+++ b/src/oic/utils/authn/user.py
@@ -364,10 +364,14 @@ class BasicAuthn(UserAuthnMethod):
 
     def verify_password(self, user, password):
         if user in self.passwd:
-            if as_unicode(password) != as_unicode(self.passwd[user]):
-                raise FailedAuthentication("Wrong password")
+            _pwd = self.passwd[user]
+            if six.PY2:
+                if isinstance(_pwd, str):
+                    _pwd = _pwd.decode('utf-8')
+            if _pwd != password:
+                raise FailedAuthentication('Wrong user/password combination')
         else:
-            raise FailedAuthentication('Unknown user')
+            raise FailedAuthentication('Wrong user/password combination')
 
     def authenticated_as(self, cookie=None, authorization="", **kwargs):
         """

--- a/src/oic/utils/authn/user.py
+++ b/src/oic/utils/authn/user.py
@@ -7,9 +7,9 @@ from future.moves.urllib.parse import parse_qs
 
 import base64
 import logging
-import six
 import time
 
+import six
 from jwkest import as_unicode
 
 from oic.exception import ImproperlyConfigured

--- a/src/oic/utils/authn/user.py
+++ b/src/oic/utils/authn/user.py
@@ -363,8 +363,11 @@ class BasicAuthn(UserAuthnMethod):
         self.passwd = pwd
 
     def verify_password(self, user, password):
-        if not (user in self.passwd and password == self.passwd[user]):
-            raise FailedAuthentication("Wrong password")
+        if user in self.passwd:
+            if as_unicode(password) != as_unicode(self.passwd[user]):
+                raise FailedAuthentication("Wrong password")
+        else:
+            raise FailedAuthentication('Unknown user')
 
     def authenticated_as(self, cookie=None, authorization="", **kwargs):
         """

--- a/src/oic/utils/authn/user.py
+++ b/src/oic/utils/authn/user.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from future.backports.urllib.parse import unquote
+from future.backports.urllib.parse import unquote_plus
 from future.backports.urllib.parse import urlencode
 from future.backports.urllib.parse import urlsplit
 from future.backports.urllib.parse import urlunsplit
@@ -7,9 +7,10 @@ from future.moves.urllib.parse import parse_qs
 
 import base64
 import logging
+import six
 import time
 
-import six
+from jwkest import as_unicode
 
 from oic.exception import ImproperlyConfigured
 from oic.exception import PyoidcError
@@ -377,8 +378,10 @@ class BasicAuthn(UserAuthnMethod):
         if authorization.startswith("Basic"):
             authorization = authorization[6:]
 
-        (user, pwd) = base64.b64decode(authorization).split(":")
-        user = unquote(user)
+        _decoded = as_unicode(base64.b64decode(authorization))
+        (user, pwd) = _decoded.split(":")
+        user = unquote_plus(user)
+        pwd = unquote_plus(pwd)
         self.verify_password(user, pwd)
         return {"uid": user}, time.time()
 

--- a/tests/test_authn_user.py
+++ b/tests/test_authn_user.py
@@ -1,7 +1,10 @@
+import base64
 
 import pytest
+from future.backports.urllib.parse import quote_plus
 
 from oic.exception import ImproperlyConfigured
+from oic.utils.authn.user import BasicAuthn
 from oic.utils.authn.user import SymKeyAuthn
 
 
@@ -15,3 +18,22 @@ def test_symkeyauthn_improperly_configured(provider):
         )
     expected_msg = "SymKeyAuthn.symkey cannot be an empty value"
     assert expected_msg in str(err.value)
+
+
+def test_basic_authn_authenticate_as():
+    pwd_database = {
+        'Diana': 'Piano player',
+        'NonAscii': '€&+%#@äää'
+    }
+    ba = BasicAuthn(None, pwd=pwd_database)
+
+    for user, passwd in pwd_database.items():
+        credentials = "{}:{}".format(quote_plus(user),
+                                     quote_plus(passwd))
+
+        authz = base64.urlsafe_b64encode(credentials.encode("utf-8")).decode(
+            "utf-8")
+        authorization_string = "Basic {}".format(authz)
+
+        uid, when = ba.authenticated_as(authorization=authorization_string)
+        assert uid == {'uid': user}

--- a/tests/test_authn_user.py
+++ b/tests/test_authn_user.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import base64
 
 import pytest

--- a/tests/test_authn_user.py
+++ b/tests/test_authn_user.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import base64
-import pytest
-
 from future.backports.urllib.parse import quote_plus
+
+import base64
+
+import pytest
 
 from oic.exception import ImproperlyConfigured
 from oic.utils.authn.user import BasicAuthn

--- a/tests/test_authn_user.py
+++ b/tests/test_authn_user.py
@@ -32,8 +32,7 @@ def test_basic_authn_authenticate_as():
         credentials = "{}:{}".format(quote_plus(user),
                                      quote_plus(passwd))
 
-        authz = base64.urlsafe_b64encode(credentials.encode("utf-8")).decode(
-            "utf-8")
+        authz = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
         authorization_string = "Basic {}".format(authz)
 
         uid, when = ba.authenticated_as(authorization=authorization_string)

--- a/tests/test_authn_user.py
+++ b/tests/test_authn_user.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import base64
-
 import pytest
+
 from future.backports.urllib.parse import quote_plus
 
 from oic.exception import ImproperlyConfigured

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import base64
 import os
 
 import pytest
+from future.backports.urllib.parse import quote_plus
 from jwkest import as_bytes
 from jwkest import b64e
 from jwkest.jwk import SYMKey
@@ -52,10 +53,9 @@ class TestClientSecretBasic(object):
 
         csb = ClientSecretBasic(client)
         http_args = csb.construct(cis)
-
+        cred = '{}:{}'.format(quote_plus("A"), quote_plus("boarding pass"))
         assert http_args == {"headers": {"Authorization": "Basic {}".format(
-            base64.urlsafe_b64encode("A:boarding pass".encode("utf-8")).decode(
-                "utf-8"))}}
+            base64.urlsafe_b64encode(cred.encode("utf-8")).decode("utf-8"))}}
 
     def test_does_not_remove_padding(self):
         cis = AccessTokenRequest(code="foo", redirect_uri="http://example.com")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -55,7 +55,7 @@ class TestClientSecretBasic(object):
         http_args = csb.construct(cis)
         cred = '{}:{}'.format(quote_plus("A"), quote_plus("boarding pass"))
         assert http_args == {"headers": {"Authorization": "Basic {}".format(
-            base64.urlsafe_b64encode(cred.encode("utf-8")).decode("utf-8"))}}
+            base64.b64encode(cred.encode("utf-8")).decode("utf-8"))}}
 
     def test_does_not_remove_padding(self):
         cis = AccessTokenRequest(code="foo", redirect_uri="http://example.com")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,11 @@
 # pylint: disable=missing-docstring,no-self-use
 
+from future.backports.urllib.parse import quote_plus
+
 import base64
 import os
 
 import pytest
-from future.backports.urllib.parse import quote_plus
 from jwkest import as_bytes
 from jwkest import b64e
 from jwkest.jwk import SYMKey


### PR DESCRIPTION
… identifier and secret MUST be x-www-form-urlencoded when doing client_secret_basic client authentication.

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
