### PR TITLE
Catch ValueError for better error message

### DIFF
--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -1034,11 +1034,12 @@ class Client(oauth2.Client):
         if r.status_code == 200:
             try:
                 pcr = response_cls().from_json(r.text)
-            except Exception:
+            except Exception as e:
                 # FIXME: This should catch specific exception from `from_json()`
-                _err_txt = "Faulty provider config response: {}".format(r.text)
+                _err_txt = "Faulty provider config response: {}".format(e)
                 logger.error(sanitize(_err_txt))
                 raise ParseError(_err_txt)
+
         # elif r.status_code == 302 or r.status_code == 301:
         #     while r.status_code == 302 or r.status_code == 301:
         #         redirect_header = r.headers["location"]


### PR DESCRIPTION
Instead raising the provider configuration this PR will catch ValueError from the ProviderConfigurationResponse.from_dict() and present that as the error message.

Instead of this
```
ParseError: Faulty provider config response: {
  "token_endpoint_auth_signing_alg_values_supported" : [ "RS256" ],
  "id_token_signing_alg_values_supported" : [ "RS256" ],
  "userinfo_endpoint" : "https://example.org/userinfo",
  "authorization_endpoint" : "https://example.org/authorize",
  "token_endpoint" : "https://example.org/token",
  "jwks_uri" : "https://example.org/jwks",
  "claims_supported" : [ "family_name", "given_name", "name", "auth_time", "iss", "sub" ],
  "scopes_supported" : [ "openid" ],
  "subject_types_supported" : [ "public" ],
  "response_types_supported" : [ "code" ],
  "claims_parameter_supported" : "false",
  "token_endpoint_auth_methods_supported" : [ "client_secret_basic" ],
  "issuer" : "https://example.org"
}
```
ParseError will look like this
```
ParseError: Faulty provider config response: "false", wrong type of value for "claims_parameter_supported"
```