### PR TITLE
Avoid TypeError in Python 3.x from integer status codes

### DIFF
--- a/src/oic/utils/http_util.py
+++ b/src/oic/utils/http_util.py
@@ -63,9 +63,12 @@ class Response(object):
 
         self.headers.append(("Content-type", _content_type))
 
-    def __call__(self, environ, start_response, **kwargs):
+    def _start_response(self, start_response):
         name = http_client.responses.get(self.status_code, 'UNKNOWN')
         start_response("{} {}".format(self.status_code, name), self.headers)
+
+    def __call__(self, environ, start_response, **kwargs):
+        self._start_response(start_response)
         return self.response(self.message, **kwargs)
 
     def _response(self, message="", **argv):
@@ -140,7 +143,7 @@ class Redirect(Response):
     def __call__(self, environ, start_response, **kwargs):
         location = self.message
         self.headers.append(('location', location))
-        start_response(str(self.status_code), self.headers)
+        self._start_response(start_response)
         return self.response((location, location, location))
 
 
@@ -158,7 +161,7 @@ class SeeOther(Response):
             except UnicodeDecodeError:
                 pass
         self.headers.append(('location', location))
-        start_response(str(self.status_code), self.headers)
+        self._start_response(start_response)
         return self.response((location, location, location))
 
 

--- a/src/oic/utils/http_util.py
+++ b/src/oic/utils/http_util.py
@@ -140,7 +140,7 @@ class Redirect(Response):
     def __call__(self, environ, start_response, **kwargs):
         location = self.message
         self.headers.append(('location', location))
-        start_response(self.status_code, self.headers)
+        start_response(str(self.status_code), self.headers)
         return self.response((location, location, location))
 
 
@@ -158,7 +158,7 @@ class SeeOther(Response):
             except UnicodeDecodeError:
                 pass
         self.headers.append(('location', location))
-        start_response(self.status_code, self.headers)
+        start_response(str(self.status_code), self.headers)
         return self.response((location, location, location))
 
 


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [x] The documentation has been updated, if necessary.
---

Ran into this small bug running in Python 3 for redirect responses.