### PR TITLE
change require_request_uri_registration default value to False

### DIFF
--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -835,7 +835,7 @@ class ProviderConfigurationResponse(Message):
                  "claims_parameter_supported": False,
                  "request_parameter_supported": False,
                  "request_uri_parameter_supported": True,
-                 "require_request_uri_registration": True,
+                 "require_request_uri_registration": False,
                  "grant_types_supported": ["authorization_code", "implicit"]}
 
     def verify(self, **kwargs):


### PR DESCRIPTION
see openid-certification/oidctest#93

see http://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata where the default is "False" if not provided

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
