### PR TITLE
Bailed out early if 'iss' is missing from a signed JWT.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on the [KeepAChangeLog] project.
 ## 0.14.0 [2018-05-15]
 
 ### Fixed
+- [#549] Added a check for the presence of 'iss' when verifying the signature of a JWT
 - [#534] Fixed a bug in client_secret_basic authentication
 - [#503] Fix error on UserInfo endpoint for removed clients
 - [#508] JWT now uses verify keys for JWT verification
@@ -45,6 +46,7 @@ The format is based on the [KeepAChangeLog] project.
 [#532]: https://github.com/OpenIDC/pyoidc/pull/532
 [#498]: https://github.com/OpenIDC/pyoidc/issues/498
 [#534]: https://github.com/OpenIDC/pyoidc/pull/534
+[#549]: https://github.com/OpenIDC/pyoidc/pull/XXX
 
 ## 0.13.1 [2018-04-06]
 

--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -652,6 +652,9 @@ class Message(MutableMapping):
                 jso = _jwt.payload()
                 _header = _jwt.headers
 
+                if 'iss' not in jso or not jso['iss']:
+                    raise MissingRequiredValue("No 'iss' value")
+
                 if key is None and keyjar is not None:
                     key = keyjar.get_verify_key(owner="")
                 elif key is None:

--- a/tests/test_oic_message.py
+++ b/tests/test_oic_message.py
@@ -493,6 +493,21 @@ class TestAccessTokenResponse(object):
         with pytest.raises(WrongSigningAlgorithm):
             at.verify(key=[key], algs={"sign": "HS512"})
 
+    def test_without_iss(self):
+        _now = time_util.utc_time_sans_frac()
+        idval = {'nonce': 'KUEYfRM2VzKDaaKD', 'sub': 'EndUserSubject',
+                 'exp': _now + 3600, 'iat': _now, 'aud': 'TestClient'}
+        idts = IdToken(**idval)
+        key = SYMKey(key="TestPassword")
+        _signed_jwt = idts.to_jwt(key=[key], algorithm="HS256")
+
+        _info = {"access_token": "accessTok", "id_token": _signed_jwt,
+                 "token_type": "Bearer", "expires_in": 3600}
+
+        at = AccessTokenResponse(**_info)
+        with pytest.raises(MissingRequiredAttribute):
+            at.verify(key=[key], algs={"sign": "HS256"})
+
 
 def test_id_token():
     _now = time_util.utc_time_sans_frac()
@@ -512,7 +527,3 @@ def test_id_token():
     })
 
     idt.verify()
-
-
-if __name__ == "__main__":
-    test_id_token()


### PR DESCRIPTION
- [X ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---

A common error when people are constructing JWT's is to miss out on specifying 'iss'.
This will infallible lead to an exception saying no key matching the kid (if such a one was given)
could be found. When i reality the problem was that no 'iss' was given.
