### PR TITLE
Fixed uncaught exception from oic.provider.Provider.auth_init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ The format is based on the [KeepAChangeLog] project.
 ### Fixed
 - [#553] Made sure a reload would not lead to duplicated keys in a keybundle.
 - [#557] Fixed PKCE verification
+- [#562] Fixed error response from oic request with invalid params
 
 [#553]: https://github.com/OpenIDC/pyoidc/pull/553
 [#557]: https://github.com/OpenIDC/pyoidc/pull/557
+[#562]: https://github.com/OpenIDC/pyoidc/issues/562
 
 ## 0.14.0 [2018-05-15]
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -703,6 +703,13 @@ class Provider(AProvider):
 
         return req
 
+    def auth_init(self, request, request_class=AuthorizationRequest):
+        """Overriden since the filter_request can throw an InvalidRequest."""
+        try:
+            return super(Provider, self).auth_init(request, request_class)
+        except InvalidRequest as err:
+            return error_response('invalid_request', '%s' % err)
+
     def authorization_endpoint(self, request="", cookie=None, **kwargs):
         """ The AuthorizationRequest endpoint
 

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -45,6 +45,7 @@ from oic.utils.authn.client import ClientSecretBasic
 from oic.utils.authn.client import verify_client
 from oic.utils.authn.user import UserAuthnMethod
 from oic.utils.authz import AuthzHandling
+from oic.utils.http_util import Response
 from oic.utils.http_util import SeeOther
 from oic.utils.keyio import KeyBundle
 from oic.utils.keyio import KeyJar
@@ -925,6 +926,20 @@ class TestProvider(object):
         assert 'Submit This Form' in response.message
         assert 'http://example.com' in response.message
         assert '<input type="hidden" name="state" value="state"/>' in response.message
+
+    def test_auth_init_invalid(self):
+        areq = {'response_mode': 'unknown',
+                'redirect_uri': 'http://localhost:8087/authz',
+                'client_id': 'number5',
+                'scope': 'openid',
+                'response_type': 'code',
+                'client_secret': 'drickyoghurt'}
+        response = self.provider.auth_init(areq)
+
+        assert isinstance(response, Response)
+        assert response.status_code == 400
+        assert json.loads(response.message) == {'error': 'invalid_request',
+                                                'error_description': 'Contains unsupported response mode'}
 
     @patch('oic.oic.provider.utc_time_sans_frac', Mock(return_value=123456))
     def test_client_secret_expiration_time(self):


### PR DESCRIPTION
Close #562

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
