### PR TITLE
Requests timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ The format is based on the [KeepAChangeLog] project.
 - [#562] Fixed error response from oic request with invalid params
 - [#565] Fixed checking token_type in AuthorizationResponse
 
+### Added
+- [#566] Added timeout to communications to remote servers
+
 [#553]: https://github.com/OpenIDC/pyoidc/pull/553
 [#557]: https://github.com/OpenIDC/pyoidc/pull/557
 [#562]: https://github.com/OpenIDC/pyoidc/issues/562
 [#565]: https://github.com/OpenIDC/pyoidc/issues/565
+[#566]: https://github.com/OpenIDC/pyoidc/issues/566
 
 ## 0.14.0 [2018-05-15]
 

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -146,7 +146,8 @@ class Client(PBase):
     _endpoints = ENDPOINTS
 
     def __init__(self, client_id=None, client_authn_method=None,
-                 keyjar=None, verify_ssl=True, config=None, client_cert=None):
+                 keyjar=None, verify_ssl=True, config=None, client_cert=None,
+                 timeout=5):
         """
 
         :param client_id: The client identifier
@@ -156,11 +157,14 @@ class Client(PBase):
         :param keyjar: The keyjar for this client.
         :param verify_ssl: Whether the SSL certificate should be verified.
         :param client_cert: A client certificate to use.
+        :param timeout: Timeout for requests library. Can be specified either as
+            a single integer or as a tuple of integers. For more details, refer to
+            ``requests`` documentation.
         :return: Client instance
         """
 
         PBase.__init__(self, verify_ssl=verify_ssl, keyjar=keyjar,
-                       client_cert=client_cert)
+                       client_cert=client_cert, timeout=timeout)
 
         self.client_id = client_id
         self.client_authn_method = client_authn_method
@@ -959,9 +963,9 @@ class Client(PBase):
 
 
 class Server(PBase):
-    def __init__(self, keyjar=None, verify_ssl=True, client_cert=None):
+    def __init__(self, keyjar=None, verify_ssl=True, client_cert=None, timeout=5):
         PBase.__init__(self, verify_ssl=verify_ssl, keyjar=keyjar,
-                       client_cert=client_cert)
+                       client_cert=client_cert, timeout=timeout)
 
     @staticmethod
     def parse_url_request(request, url=None, query=None):

--- a/src/oic/oauth2/base.py
+++ b/src/oic/oauth2/base.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class PBase(object):
-    def __init__(self, verify_ssl=True, keyjar=None, client_cert=None):
+    def __init__(self, verify_ssl=True, keyjar=None, client_cert=None, timeout=5):
         """
         A base class for OAuth2 clients and servers
 
@@ -32,6 +32,9 @@ class PBase(object):
         :param client_cert: local cert to use as client side certificate, as a
             single file (containing the private key and the certificate) or as
             a tuple of both file's path
+        :param timeout: Timeout for requests library. Can be specified either as
+            a single integer or as a tuple of integers. For more details, refer to
+            ``requests`` documentation.
         """
 
         self.keyjar = keyjar or KeyJar(verify_ssl=verify_ssl)
@@ -43,6 +46,7 @@ class PBase(object):
             "allow_redirects": False,
             "cert": client_cert,
             "verify": verify_ssl,
+            "timeout": timeout,
         }
 
         # Event collector, for tracing

--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -418,14 +418,18 @@ class KeyJar(object):
     """ A keyjar contains a number of KeyBundles """
 
     def __init__(self, verify_ssl=True, keybundle_cls=KeyBundle,
-                 remove_after=3600):
+                 remove_after=3600, timeout=5):
         """
         :param verify_ssl: Do SSL certificate verification
+        :param timeout: Timeout for requests library. Can be specified either as
+            a single integer or as a tuple of integers. For more details, refer to
+            ``requests`` documentation.
         :return:
         """
         self.spec2key = {}
         self.issuer_keys = {}
         self.verify_ssl = verify_ssl
+        self.timeout = timeout
         self.keybundle_cls = keybundle_cls
         self.remove_after = remove_after
 
@@ -458,9 +462,9 @@ class KeyJar(object):
             raise KeyError("No jwks_uri")
 
         if "/localhost:" in url or "/localhost/" in url:
-            kc = self.keybundle_cls(source=url, verify_ssl=False, **kwargs)
+            kc = self.keybundle_cls(source=url, verify_ssl=False, timeout=self.timeout, **kwargs)
         else:
-            kc = self.keybundle_cls(source=url, verify_ssl=self.verify_ssl,
+            kc = self.keybundle_cls(source=url, verify_ssl=self.verify_ssl, timeout=self.timeout,
                                     **kwargs)
 
         try:
@@ -714,7 +718,7 @@ class KeyJar(object):
             try:
                 _keys = pcr["jwks"]["keys"]
                 self.issuer_keys[issuer].append(
-                    self.keybundle_cls(_keys, verify_ssl=self.verify_ssl))
+                    self.keybundle_cls(_keys, verify_ssl=self.verify_ssl, timeout=self.timeout))
             except KeyError:
                 pass
 
@@ -761,10 +765,10 @@ class KeyJar(object):
         else:
             try:
                 self.issuer_keys[issuer].append(
-                    self.keybundle_cls(_keys, verify_ssl=self.verify_ssl))
+                    self.keybundle_cls(_keys, verify_ssl=self.verify_ssl, timeout=self.timeout))
             except KeyError:
                 self.issuer_keys[issuer] = [self.keybundle_cls(
-                    _keys, verify_ssl=self.verify_ssl)]
+                    _keys, verify_ssl=self.verify_ssl, timeout=self.timeout)]
 
     def add_keyjar(self, keyjar):
         for iss, kblist in keyjar.items():
@@ -782,12 +786,12 @@ class KeyJar(object):
     def restore(self, info):
         for issuer, keys in info.items():
             self.issuer_keys[issuer] = [self.keybundle_cls(
-                keys, verify_ssl=self.verify_ssl)]
+                keys, verify_ssl=self.verify_ssl, timeout=self.timeout)]
 
     def copy(self):
-        copy_keyjar = KeyJar(verify_ssl=self.verify_ssl)
+        copy_keyjar = KeyJar(verify_ssl=self.verify_ssl, timeout=self.timeout)
         for issuer, keybundles in self.issuer_keys.items():
-            _kb = self.keybundle_cls(verify_ssl=self.verify_ssl)
+            _kb = self.keybundle_cls(verify_ssl=self.verify_ssl, timeout=self.timeout)
             for kb in keybundles:
                 for k in kb.keys():
                     _kb.append(copy.copy(k))

--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -61,7 +61,7 @@ K2C = {
 
 class KeyBundle(object):
     def __init__(self, keys=None, source="", cache_time=300, verify_ssl=True,
-                 fileformat="jwk", keytype="RSA", keyusage=None):
+                 fileformat="jwk", keytype="RSA", keyusage=None, timeout=5):
         """
 
         :param keys: A list of dictionaries
@@ -70,6 +70,9 @@ class KeyBundle(object):
         :param verify_ssl: Verify the SSL cert used by the server
         :param fileformat: For a local file either "jwk" or "der"
         :param keytype: Iff local file and 'der' format what kind of key it is.
+        :param timeout: Timeout for requests library. Can be specified either as
+            a single integer or as a tuple of integers. For more details, refer to
+            ``requests`` documentation.
         """
 
         self._keys = []
@@ -84,6 +87,7 @@ class KeyBundle(object):
         self.keyusage = keyusage
         self.imp_jwks = None
         self.last_updated = 0
+        self.timeout = timeout
 
         if keys:
             self.source = None
@@ -159,7 +163,7 @@ class KeyBundle(object):
         self.last_updated = time.time()
 
     def do_remote(self):
-        args = {"verify": self.verify_ssl}
+        args = {"verify": self.verify_ssl, "timeout": self.timeout}
         if self.etag:
             args["headers"] = {"If-None-Match": self.etag}
 


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
