### PR TITLE
Fix get_userinfo_claims on consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#557] Fixed PKCE verification
 - [#562] Fixed error response from oic request with invalid params
 - [#565] Fixed checking token_type in AuthorizationResponse
+- [#547] Fixed get_userinfo_claims method
 
 ### Added
 - [#566] Added timeout to communications to remote servers
@@ -21,6 +22,7 @@ The format is based on the [KeepAChangeLog] project.
 [#562]: https://github.com/OpenIDC/pyoidc/issues/562
 [#565]: https://github.com/OpenIDC/pyoidc/issues/565
 [#566]: https://github.com/OpenIDC/pyoidc/issues/566
+[#547]: https://github.com.OpenIDC/pyoidc/issues/547
 
 ## 0.14.0 [2018-05-15]
 

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -972,7 +972,7 @@ class Client(oauth2.Client):
                                                           resp.text))
 
         res = schema_class().from_json(txt=resp.text)
-        self.store_response(res, resp.txt)
+        self.store_response(res, resp.text)
         return res
 
     def handle_provider_config(self, pcr, issuer, keys=True, endpoints=True):

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -441,6 +441,32 @@ class TestOICConsumer():
         assert _eq(result.keys(),
                    ['name', 'email', 'verified', 'nickname', 'sub'])
 
+    def test_get_userinfo_claims(self):
+        _state = "state0"
+
+        args = {
+            "client_id": self.consumer.client_id,
+            "response_type": "code",
+            "scope": ["openid"],
+        }
+
+        result = self.consumer.do_authorization_request(state=_state,
+                                                        request_args=args)
+        assert result.status_code == 302
+        parsed = urlparse(result.headers["location"])
+        baseurl = "{}://{}{}".format(parsed.scheme, parsed.netloc, parsed.path)
+        assert baseurl == self.consumer.redirect_uris[0]
+
+        self.consumer.parse_response(AuthorizationResponse, info=parsed.query,
+                                     sformat="urlencoded")
+
+        response = self.consumer.complete(_state)
+
+        result = self.consumer.get_userinfo_claims(response['access_token'], self.consumer.userinfo_endpoint)
+        assert isinstance(result, OpenIDSchema)
+        assert _eq(result.keys(),
+                   ['name', 'email', 'verified', 'nickname', 'sub'])
+
     def real_test_discover(self):
         c = Consumer(None, None)
         principal = "nav@connect-op.heroku.com"


### PR DESCRIPTION
Close #547

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
