### PR TITLE
Fix SessionDB.revoke_token implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#562] Fixed error response from oic request with invalid params
 - [#565] Fixed checking token_type in AuthorizationResponse
 - [#547] Fixed get_userinfo_claims method
+- [#268] Fixed SessionDB.revoke_token implementation
 
 ### Added
 - [#566] Added timeout to communications to remote servers
@@ -22,7 +23,8 @@ The format is based on the [KeepAChangeLog] project.
 [#562]: https://github.com/OpenIDC/pyoidc/issues/562
 [#565]: https://github.com/OpenIDC/pyoidc/issues/565
 [#566]: https://github.com/OpenIDC/pyoidc/issues/566
-[#547]: https://github.com.OpenIDC/pyoidc/issues/547
+[#547]: https://github.com/OpenIDC/pyoidc/issues/547
+[#268]: https://github.com/OpenIDC/pyoidc/issues/268
 
 ## 0.14.0 [2018-05-15]
 

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -354,6 +354,20 @@ class TestSessionDB(object):
         self.sdb.revoke_token(grant)
         assert not self.sdb.is_valid(grant)
 
+    def test_revoke_all_tokens(self):
+        ae1 = AuthnEvent("uid", "salt")
+        sid = self.sdb.create_authz_session(ae1, AREQ)
+        self.sdb[sid]['sub'] = 'sub'
+
+        grant = self.sdb[sid]["code"]
+        tokens = self.sdb.upgrade_to_token(grant, issue_refresh=True)
+        access_token = tokens["access_token"]
+        refresh_token = tokens["refresh_token"]
+
+        self.sdb.revoke_all_tokens(access_token)
+        assert not self.sdb.is_valid(access_token)
+        assert not self.sdb.is_valid(refresh_token)
+
     def test_sub_to_authn_event(self):
         ae = AuthnEvent("sub", "salt", time_stamp=time.time())
         sid = self.sdb.create_authz_session(ae, AREQ)


### PR DESCRIPTION
Close #268

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
