### PR TITLE
return error when when resolving request_uri fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#565] Fixed checking token_type in AuthorizationResponse
 - [#547] Fixed get_userinfo_claims method
 - [#268] Fixed SessionDB.revoke_token implementation
+- [#571] Return error when when resolving request_uri fails
 
 ### Added
 - [#566] Added timeout to communications to remote servers
@@ -25,6 +26,7 @@ The format is based on the [KeepAChangeLog] project.
 [#566]: https://github.com/OpenIDC/pyoidc/issues/566
 [#547]: https://github.com/OpenIDC/pyoidc/issues/547
 [#268]: https://github.com/OpenIDC/pyoidc/issues/268
+[#571]: https://github.com/OpenIDC/pyoidc/issues/571
 
 ## 0.14.0 [2018-05-15]
 

--- a/src/oic/extension/device_flow.py
+++ b/src/oic/extension/device_flow.py
@@ -55,7 +55,6 @@ class DeviceFlowServer(SingleService):
         self.device2user[device_code] = user_code
         self.user_auth[user_code] = False
         self.client_id2device[_req['client_id']] = device_code
-        # in_a_while(minutes=15)
         self.device_code_expire_at[
             device_code] = time_sans_frac() + self.device_code_life_time
 

--- a/src/oic/extension/message.py
+++ b/src/oic/extension/message.py
@@ -161,23 +161,11 @@ class RegistrationRequest(Message):
                 if resp.status_code not in SUCCESSFUL:
                     raise MissingPage(self[uri])
 
-        # if "grant_types" in self and "response_types" in self:
-        #     for typ in self["grant_types"]:
-        #         if typ == "authorization_code":
-        #             assert "code" in self["response_types"]
-        #         elif typ == "implicit":
-        #             assert "token" in self["response_types"]
-
         try:
             ss = self['software_statement']
         except KeyError:
             pass
         else:
-            # need to get the client keys before I can verify any signature
-            # kj = kwargs['keyjar']
-            # The case where jwks_uri is used
-            # try:
-            #     kj.add(,self['jwks_uri'])
             _ss = []
             for _s in ss:
                 _ss.append(unpack_software_statement(_s, '', kwargs['keyjar']))

--- a/src/oic/extension/provider.py
+++ b/src/oic/extension/provider.py
@@ -567,7 +567,6 @@ class Provider(provider.Provider):
             _provider_info["jwks_uri"] = self.jwks_uri
 
         for endp in self.endp:
-            # _log_info("# %s, %s" % (endp, endp.name))
             _provider_info['{}_endpoint'.format(endp.etype)] = os.path.join(
                 self.baseurl, endp.url)
 

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -275,13 +275,6 @@ class Client(PBase):
         return uri
 
     def get_grant(self, state, **kwargs):
-        # try:
-        # _state = kwargs["state"]
-        # if not _state:
-        #         _state = self.state
-        # except KeyError:
-        #     _state = self.state
-
         try:
             return self.grant[state]
         except KeyError:
@@ -325,13 +318,11 @@ class Client(PBase):
         if request_args is None:
             request_args = {}
 
-        # logger.debug("request_args: %s" % sanitize(request_args))
         kwargs = self._parse_args(request, **request_args)
 
         if extra_args:
             kwargs.update(extra_args)
-            # logger.debug("kwargs: %s" % sanitize(kwargs))
-        # logger.debug("request: %s" % sanitize(request))
+        logger.debug("request: %s" % sanitize(request))
         return request(**kwargs)
 
     def construct_Message(self, request=Message, request_args=None,
@@ -409,19 +400,6 @@ class Client(PBase):
             pass
 
         return self.construct_request(request, request_args, extra_args)
-
-    # def construct_TokenRevocationRequest(self,
-    #                                      request=TokenRevocationRequest,
-    #                                      request_args=None, extra_args=None,
-    #                                      **kwargs):
-    #
-    #     if request_args is None:
-    #         request_args = {}
-    #
-    #     token = self.get_token(**kwargs)
-    #
-    #     request_args["token"] = token.access_token
-    #     return self.construct_request(request, request_args, extra_args)
 
     def construct_ResourceRequest(self, request=ResourceRequest,
                                   request_args=None, extra_args=None,
@@ -524,8 +502,6 @@ class Client(PBase):
         if sformat == "urlencoded":
             info = self.get_urlinfo(info)
 
-        # if self.events:
-        #    self.events.store('Response', info)
         resp = response().deserialize(info, sformat, **kwargs)
         msg = 'Initial response parsing => "{}"'
         logger.debug(msg.format(sanitize(resp.to_dict())))
@@ -789,26 +765,6 @@ class Client(PBase):
             grant.delete_token(token)
         return response
 
-    # def do_revocate_token(self, request=TokenRevocationRequest,
-    #                       scope="", state="", body_type="json", method="POST",
-    #                       request_args=None, extra_args=None, http_args=None,
-    #                       response_cls=None, authn_method=""):
-    #
-    #     url, body, ht_args, csi = self.request_info(request, method=method,
-    #                                                 request_args=request_args,
-    #                                                 extra_args=extra_args,
-    #                                                 scope=scope, state=state,
-    #                                                 authn_method=authn_method)
-    #
-    #     if http_args is None:
-    #         http_args = ht_args
-    #     else:
-    #         http_args.update(ht_args)
-    #
-    #     return self.request_and_return(url, response_cls, method, body,
-    #                                    body_type, state=state,
-    #                                    http_args=http_args)
-
     def do_any(self, request, endpoint="", scope="", state="", body_type="json",
                method="POST", request_args=None, extra_args=None,
                http_args=None, response=None, authn_method=""):
@@ -991,7 +947,6 @@ class Server(PBase):
         if not keyjar:
             keyjar = self.keyjar
 
-        # areq = message().from_(txt, keys, verify)
         areq = request().deserialize(txt, "jwt", keyjar=keyjar,
                                      verify=verify, **kwargs)
         if verify:
@@ -999,7 +954,6 @@ class Server(PBase):
         return areq
 
     def parse_body_request(self, request=AccessTokenRequest, body=None):
-        # req = message(reqmsg).from_urlencoded(body)
         req = request().deserialize(body, "urlencoded")
         req.verify()
         return req

--- a/src/oic/oauth2/base.py
+++ b/src/oic/oauth2/base.py
@@ -60,7 +60,6 @@ class PBase(object):
         for _, a in list(self.cookiejar._cookies.items()):
             for _, b in list(a.items()):
                 for cookie in list(b.values()):
-                    # print cookie
                     cookie_dict[cookie.name] = cookie.value
 
         return cookie_dict
@@ -102,9 +101,6 @@ class PBase(object):
 
         try:
             _cookie = r.headers["set-cookie"]
-            # Telekom fix
-            # set_cookie = set_cookie.replace(
-            # "=;Path=/;Expires=Thu, 01-Jan-1970 00:00:01 GMT;HttpOnly,", "")
             logger.debug("RECEIVED COOKIE")
             try:
                 set_cookie(self.cookiejar, SimpleCookie(_cookie))

--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -604,14 +604,6 @@ class Message(MutableMapping):
         :param kwargs: Extra key word arguments
         :return: A class instance
         """
-        # if key is None and keyjar is not None:
-        #     key = keyjar.get_verify_key(owner="")
-        # elif key is None:
-        #     key = []
-        #
-        # if keyjar is not None and "sender" in kwargs:
-        #     key.extend(keyjar.get_verify_key(owner=kwargs["sender"]))
-
         _jw = jwe.factory(txt)
         if _jw:
             logger.debug("JWE headers: {}".format(_jw.jwt.headers))
@@ -705,7 +697,6 @@ class Message(MutableMapping):
                 raise NotAllowedValue(val)
         elif isinstance(typ, list):
             if isinstance(val, list):
-                # _typ = typ[0]
                 for item in val:
                     if item not in _allowed:
                         raise NotAllowedValue(val)
@@ -815,9 +806,6 @@ class Message(MutableMapping):
             return False
 
         return True
-
-    # def __getattr__(self, item):
-    #        return self._dict[item]
 
     def __delitem__(self, key):
         del self._dict[key]

--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -772,10 +772,6 @@ class Provider(object):
 
     def token_scope_check(self, areq, info):
         """ Not implemented here """
-        # if not self.subset(areq["scope"], _info["scope"]):
-        # logger.info("Asked for scope which is not subset of previous defined")
-        # err = TokenErrorResponse(error="invalid_scope")
-        #     return Response(err.to_json(), content="application/json")
         return None
 
     def token_endpoint(self, authn="", **kwargs):

--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -416,6 +416,9 @@ class Provider(object):
             logger.debug("No AuthzRequest")
             return error_response("invalid_request", "Can not parse AuthzRequest")
 
+        if isinstance(areq, Response):
+            return areq
+
         areq = self.filter_request(areq)
 
         if self.events:

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -220,7 +220,6 @@ class Grant(oauth2.Grant):
 
 
 PREFERENCE2PROVIDER = {
-    # "require_signed_request_object": "request_object_algs_supported",
     "request_object_signing_alg": "request_object_signing_alg_values_supported",
     "request_object_encryption_alg":
         "request_object_encryption_alg_values_supported",
@@ -464,9 +463,6 @@ class Client(oauth2.Client):
                                        request_param=None, **kwargs):
 
         if request_args is not None:
-            # if "claims" in request_args:
-            # kwargs["claims"] = request_args["claims"]
-            #     del request_args["claims"]
             if "nonce" not in request_args:
                 _rt = request_args["response_type"]
                 if "token" in _rt or "id_token" in _rt:
@@ -634,9 +630,6 @@ class Client(oauth2.Client):
             request_args["state"] = kwargs["state"]
         elif "state" in request_args:
             kwargs["state"] = request_args["state"]
-
-        # if "redirect_url" not in request_args:
-        #            request_args["redirect_url"] = self.redirect_url
 
         return self._id_token_based(request, request_args, extra_args,
                                     **kwargs)
@@ -1040,23 +1033,7 @@ class Client(oauth2.Client):
                 logger.error(sanitize(_err_txt))
                 raise ParseError(_err_txt)
 
-        # elif r.status_code == 302 or r.status_code == 301:
-        #     while r.status_code == 302 or r.status_code == 301:
-        #         redirect_header = r.headers["location"]
-        #         if not urlparse(redirect_header).scheme:
-        #             # Relative URL was provided - construct new redirect
-        #             # using an issuer
-        #             _split = urlparse(issuer)
-        #             new_url = urlunparse((_split.scheme, _split.netloc,
-        #                                   as_unicode(redirect_header),
-        #                                   _split.params,
-        #                                   _split.query, _split.fragment))
-        #             r = self.http_request(new_url)
-        #             if r.status_code == 200:
-        #                 pcr = response_cls().from_json(r.text)
-        #                 break
-
-        # logger.debug("Provider info: %s" % sanitize(pcr))
+        logger.debug("Provider info: %s" % sanitize(pcr))
         if pcr is None:
             raise CommunicationError(
                 "Trying '%s', status %s" % (url, r.status_code))
@@ -1177,7 +1154,6 @@ class Client(oauth2.Client):
                 try:
                     self.behaviour[_pref] = PROVIDER_DEFAULT[_pref]
                 except KeyError:
-                    # self.behaviour[_pref]= vals[0]
                     if isinstance(pcr.c_param[_prov][0], list):
                         self.behaviour[_pref] = []
                     else:
@@ -1401,7 +1377,6 @@ class Client(oauth2.Client):
         return subject, domain
 
     def discover(self, principal):
-        # subject, host = self.normalization(principal)
         return self.wf.discovery_query(principal)
 
     def sign_enc_algs(self, typ):
@@ -1782,7 +1757,6 @@ class Server(oauth2.Server):
                 if key == "auth_time":
                     extra["auth_time"] = auth_time
                 elif key == "acr":
-                    # ["2","http://id.incommon.org/assurance/bronze"]
                     extra["acr"] = verify_acr_level(val, loa)
         else:
             if auth_time:

--- a/src/oic/oic/claims_provider.py
+++ b/src/oic/oic/claims_provider.py
@@ -37,22 +37,6 @@ class UserClaimsResponse(Message):
                "access_token": SINGLE_OPTIONAL_STRING}
 
 
-#    def verify(self, **kwargs):
-#        if "jwt" in self:
-#            # Try to decode the JWT, checks the signature
-#            args = dict([(claim, kwargs[claim]) for claim in ["key","keyjar"] \
-#                            if claim in kwargs])
-#            try:
-#                item = OpenIDSchema().from_jwt(str(self["jwt"]), **args)
-#            except Exception, _err:
-#                raise
-#
-#            if not item.verify(**kwargs):
-#                return False
-#
-#        return super(self.__class__, self).verify(**kwargs)
-
-
 class UserInfoClaimsRequest(Message):
     c_param = {"access_token": SINGLE_REQUIRED_STRING}
 
@@ -153,7 +137,6 @@ class ClaimsServer(Provider):
         _log_info("Claims_info_endpoint query: '%s'" % sanitize(request))
 
         ucreq = self.srvmethod.parse_userinfo_claims_request(request)
-        # _log_info("request: %s" % sanitize(ucreq))
 
         # Bearer header or body
         access_token = bearer_auth(ucreq, authn)

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -402,7 +402,6 @@ class Consumer(Client):
         if resp.type() == "ErrorResponse":
             raise TokenError(resp.error, resp)
 
-        # self._backup(self.sdb["seed:%s" % _cli.seed])
         self._backup(state)
 
         return resp

--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# -*- coding: utf-8 -*-
 from future.backports.urllib.parse import urlparse
 
 import inspect
@@ -101,21 +101,6 @@ def idtoken_deser(val, sformat="urlencoded"):
     # id_token are always serialized as a JWT
     return IdToken().deserialize(val, "jwt")
 
-
-# def idtokenclaim_deser(val, sformat="urlencoded"):
-#     if sformat in ["dict", "json"]:
-#         if not isinstance(val, basestring):
-#             val = json.dumps(val)
-#             sformat = "json"
-#     return IDTokenClaim().deserialize(val, sformat)
-#
-#
-# def userinfo_deser(val, sformat="urlencoded"):
-#     if sformat in ["dict", "json"]:
-#         if not isinstance(val, basestring):
-#             val = json.dumps(val)
-#             sformat = "json"
-#     return UserInfoClaim().deserialize(val, sformat)
 
 def address_deser(val, sformat="urlencoded"):
     if sformat in ["dict", "json"]:
@@ -242,8 +227,6 @@ def claims_request_deser(val, sformat="json"):
 OPTIONAL_ADDRESS = (Message, False, msg_ser, address_deser, False)
 OPTIONAL_LOGICAL = (bool, False, None, None, False)
 OPTIONAL_MULTIPLE_Claims = (Message, False, claims_ser, claims_deser, False)
-# SINGLE_OPTIONAL_USERINFO_CLAIM = (Message, False, msg_ser, userinfo_deser)
-# SINGLE_OPTIONAL_ID_TOKEN_CLAIM = (Message, False, msg_ser, idtokenclaim_deser)
 
 SINGLE_OPTIONAL_IDTOKEN = (six.string_types, False, msg_ser, None, False)
 
@@ -321,7 +304,6 @@ class AuthorizationResponse(message.AuthorizationResponse,
     c_param.update(message.AccessTokenResponse.c_param)
     c_param.update({
         "code": SINGLE_OPTIONAL_STRING,
-        # "nonce": SINGLE_OPTIONAL_STRING,
         "access_token": SINGLE_OPTIONAL_STRING,
         "token_type": SINGLE_OPTIONAL_STRING,
         "id_token": SINGLE_OPTIONAL_IDTOKEN,
@@ -407,7 +389,6 @@ class AuthorizationRequest(message.AuthorizationRequest):
             "registration": SINGLE_OPTIONAL_JSON,
             "request": SINGLE_OPTIONAL_STRING,
             "request_uri": SINGLE_OPTIONAL_STRING,
-            # "session_state": SINGLE_OPTIONAL_STRING,
             "response_mode": SINGLE_OPTIONAL_STRING,
         }
     )
@@ -577,9 +558,6 @@ class RegistrationRequest(Message):
         "default_acr_values": OPTIONAL_LIST_OF_STRINGS,
         "initiate_login_uri": SINGLE_OPTIONAL_STRING,
         "request_uris": OPTIONAL_LIST_OF_STRINGS,
-        # "client_id": SINGLE_OPTIONAL_STRING,
-        # "client_secret": SINGLE_OPTIONAL_STRING,
-        # "access_token": SINGLE_OPTIONAL_STRING,
         "post_logout_redirect_uris": OPTIONAL_LIST_OF_STRINGS,
     }
     c_default = {"application_type": "web", "response_types": ["code"]}
@@ -763,7 +741,6 @@ class EndSessionResponse(Message):
 
 
 class Claims(Message):
-    # c_param = {"*": SINGLE_OPTIONAL_JSON_CONV}
     pass
 
 
@@ -772,16 +749,6 @@ class ClaimsRequest(Message):
         "userinfo": OPTIONAL_MULTIPLE_Claims,
         "id_token": OPTIONAL_MULTIPLE_Claims
     }
-
-
-# class UserInfoClaim(Message):
-#     c_param = {"claims": OPTIONAL_MULTIPLE_Claims,
-#                "preferred_locale": SINGLE_OPTIONAL_STRING}
-#
-#
-# class IDTokenClaim(Message):
-#     c_param = {"claims": OPTIONAL_MULTIPLE_Claims,
-#                "max_age": SINGLE_OPTIONAL_INT}
 
 
 class OpenIDRequest(AuthorizationRequest):
@@ -830,9 +797,6 @@ class ProviderConfigurationResponse(Message):
         "op_tos_uri": SINGLE_OPTIONAL_STRING,
         "check_session_iframe": SINGLE_OPTIONAL_STRING,
         "end_session_endpoint": SINGLE_OPTIONAL_STRING,
-        # "jwk_encryption_url": SINGLE_OPTIONAL_STRING,
-        # "x509_url": SINGLE_REQUIRED_STRING,
-        # "x509_encryption_url": SINGLE_OPTIONAL_STRING,
     }
     c_default = {"version": "3.0",
                  "token_endpoint_auth_methods_supported": [
@@ -955,8 +919,6 @@ MSG = {
     "EndSessionRequest": EndSessionRequest,
     "EndSessionResponse": EndSessionResponse,
     "Claims": Claims,
-    # "UserInfoClaim": UserInfoClaim,
-    # "IDTokenClaim": IDTokenClaim,
     "OpenIDRequest": OpenIDRequest,
     "ProviderConfigurationResponse": ProviderConfigurationResponse,
     "AuthnToken": AuthnToken,

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -116,14 +116,6 @@ def secret(seed, sid):
     return csum.hexdigest()
 
 
-# def update_info(aresp, sdict):
-#    for prop in aresp._schema["param"].keys():
-#        try:
-#            aresp[prop] = sdict[prop]
-#        except KeyError:
-#            pass
-
-
 def code_token_response(**kwargs):
     _areq = kwargs["areq"]
     _scode = kwargs["scode"]
@@ -1658,7 +1650,6 @@ class Provider(AProvider):
             _provider_info["jwks_uri"] = self.jwks_uri
 
         for endp in self.endp:
-            # _log_info("# %s, %s" % (endp, endp.name))
             if not self.baseurl.endswith('/'):
                 baseurl = self.baseurl + '/'
             else:

--- a/src/oic/utils/authn/client.py
+++ b/src/oic/utils/authn/client.py
@@ -195,7 +195,6 @@ class BearerHeader(ClientAuthnMethod):
                 _acc_token = request_args["access_token"]
 
         # Do I need to base64 encode the access token ? Probably !
-        # _bearer = "Bearer %s" % base64.b64encode(_acc_token)
         _bearer = "Bearer %s" % _acc_token
         if http_args is None:
             http_args = {"headers": {}}
@@ -299,7 +298,6 @@ class JWSAuthnMethod(ClientAuthnMethod):
         """
 
         # audience is the OP endpoint
-        # audience = self.cli._endpoint(REQUEST2ENDPOINT[cis.type()])
         # OR OP identifier
         algorithm = None
         if kwargs['authn_endpoint'] in ['token', 'refresh']:
@@ -381,7 +379,6 @@ class JWSAuthnMethod(ClientAuthnMethod):
         logger.debug("authntoken: %s" % sanitize(bjwt.to_dict()))
         areq['parsed_client_assertion'] = bjwt
 
-        # logger.debug("known clients: %s" % sanitize(self.cli.cdb.keys()))
         try:
             cid = kwargs["client_id"]
         except KeyError:
@@ -442,9 +439,6 @@ class PrivateKeyJWT(JWSAuthnMethod):
     def get_signing_key(self, algorithm):
         return self.cli.keyjar.get_signing_key(alg2keytype(algorithm), "",
                                                alg=algorithm)
-
-
-# from oic.utils.authn.client_saml import SAML2_BEARER_ASSERTION_TYPE
 
 
 CLIENT_AUTHN_METHOD = {

--- a/src/oic/utils/authn/client_saml.py
+++ b/src/oic/utils/authn/client_saml.py
@@ -41,9 +41,6 @@ else:
 
         def _verify_saml2_assertion(self, assertion):
             subject = assertion.subject
-            # client_id = subject.name_id.text
-            # who_ever_issued_it = assertion.issuer.text
-
             audience = []
             for ar in subject.audience_restiction:
                 for aud in ar.audience:

--- a/src/oic/utils/authn/saml.py
+++ b/src/oic/utils/authn/saml.py
@@ -329,7 +329,6 @@ class SAMLAuthnMethod(UserAuthnMethod):
                 _sid = req_id
 
             _rstate = rndstr()
-            # self.cache.relay_state[_rstate] = came_from
             ht_args = _cli.apply_binding(binding, msg_str, destination,
                                          relay_state=_rstate)
 

--- a/src/oic/utils/authn/user.py
+++ b/src/oic/utils/authn/user.py
@@ -273,11 +273,6 @@ class UsernamePasswordMako(UserAuthnMethod):
         """
         Put up the login form
         """
-        # if cookie:
-        #     headers = [cookie]
-        # else:
-        #     headers = []
-
         resp = Response()
 
         argv = self.templ_arg_func(end_point_index, **kwargs)
@@ -335,7 +330,6 @@ class UsernamePasswordMako(UserAuthnMethod):
                 _qp = self.get_multi_auth_cookie(kwargs['cookie'])
 
         logger.debug("Password verification succeeded.")
-        # if "cookie" not in kwargs or self.srv.cookie_name not in kwargs["cookie"]:
         headers = [self.create_cookie(_dict["login"], "upm")]
         try:
             return_to = self.generate_return_url(kwargs["return_to"], _qp)

--- a/src/oic/utils/rp/__init__.py
+++ b/src/oic/utils/rp/__init__.py
@@ -120,8 +120,6 @@ class Client(oic.Client):
                 raise OIDCError("Access denied")
 
         _state = authresp["state"]
-        # if session["state"] != authresp["state"]:
-        #     self._err("Received state not the same as expected.")
 
         try:
             _id_token = authresp['id_token']

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -789,7 +789,6 @@ class SessionDB(object):
         return True
 
     def is_revoked(self, sid):
-        # typ, sid = self.access_token.type_and_key(token)
         try:
             return self[sid]["revoked"]
         except KeyError:

--- a/src/oic/utils/stateless.py
+++ b/src/oic/utils/stateless.py
@@ -52,7 +52,6 @@ class StateLess(object):
         _cont = Content(typ="code", sub=sub, aud=areq["redirect_uri"],
                         val=epoch_in_a_while(self.validity["grant"]))
 
-        # return _cont.to_jwe(self.keys, self.enc, self.alg)
         return _cont
 
     def upgrade_to_token(self, cont, issue_refresh=False):

--- a/src/oic/utils/time_util.py
+++ b/src/oic/utils/time_util.py
@@ -92,7 +92,6 @@ def parse_duration(duration):
     dic = dict([(typ, 0) for (code, typ) in D_FORMAT])
 
     for code, typ in D_FORMAT:
-        # print duration[index:], code
         if duration[index] == '-':
             raise TimeUtilError("Negation not allowed on individual items")
         if code == "T":

--- a/src/oic/utils/userinfo/distaggr.py
+++ b/src/oic/utils/userinfo/distaggr.py
@@ -134,7 +134,6 @@ class DistributedAggregatedUserInfo(UserInfo):
 
         else:
             # default is what "openid" demands which is sub
-            # result = identity
             result = {"sub": userid}
 
         return OpenIDSchema(**result)

--- a/tests/fakeoicsrv.py
+++ b/tests/fakeoicsrv.py
@@ -121,7 +121,6 @@ class MyFakeOICServer(Server):
 
                 _dict = by_schema(AuthorizationResponse(), **_dict)
                 resp = AuthorizationResponse(**_dict)
-                # resp.code = grant
             else:
                 _state = req["state"]
                 resp = AuthorizationResponse(state=_state,

--- a/tests/mitmsrv.py
+++ b/tests/mitmsrv.py
@@ -118,7 +118,6 @@ class MITMServer(Server):
 
                 _dict = by_schema(AuthorizationResponse(), **_dict)
                 resp = AuthorizationResponse(**_dict)
-                # resp.code = grant
             else:
                 _state = req["state"]
                 resp = AuthorizationResponse(state=_state,

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -214,10 +214,6 @@ class TestClient(object):
         assert token.expires_in == 3600
         assert token.refresh_token == "tGzv3JOkF0XG5Qx2TlKWIA"
 
-        # I'm dropping parameters I don't recognize
-        # with pytest.raises(AttributeError): # TODO not satisfied
-        #     nothing = token.example_parameter
-
     def test_get_access_token_refresh_with_refresh_token(self):
         self.client.grant["foo"] = Grant()
         _get = time_util.utc_time_sans_frac() + 60
@@ -287,31 +283,11 @@ class TestClient(object):
                                 "redirect_uri", "foo", 'state'])
         assert req["foo"] == "bar"
 
-    # def test_construct_TokenRevocationRequest(self):
-    #     self.client.grant["foo"] = Grant()
-    #     _get = time_util.utc_time_sans_frac() + 60
-    #     self.client.grant["foo"].grant_expiration_time = _get
-    #     self.client.grant["foo"].code = "access_code"
-    #     resp = AccessTokenResponse(refresh_token="refresh_with_me",
-    #                                access_token="access")
-    #     token = Token(resp)
-    #     self.client.grant["foo"].tokens.append(token)
-    #
-    #     state = "foo"
-    #     query = "code=SplxlOBeZQQYbYS6WxSbIA&state={}".format(state)
-    #     self.client.parse_response(AuthorizationResponse,
-    #                                info=query, sformat="urlencoded")
-    #
-    #     req = self.client.construct_TokenRevocationRequest(state=state)
-    #     assert _eq(req.keys(), ['token'])
-    #     assert req["token"] == "access"
-
     def test_request_info_simple(self):
         req_args = {"state": "hmm", "response_type": "code"}
         uri, body, h_args, cis = self.client.request_info(AuthorizationRequest,
                                                           request_args=req_args)
 
-        # default == "POST"
         assert uri == self.authorization_endpoint
         body_elts = body.split('&')
         expected_body = "state=hmm&redirect_uri={}&response_type=code&client_id=1".format(

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# from oic.oauth2 import KeyStore
 from future.backports.urllib.parse import urlparse
 
 import json
@@ -202,7 +201,6 @@ class TestClient(object):
         args = {
             "code": "code",
             "redirect_uri": self.client.redirect_uris[0],
-            # "client_id": self.client.client_id,
         }
 
         url, query, ht_args, cis = self.client.request_info(

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -167,7 +167,6 @@ class DummyAuthn(UserAuthnMethod):
             return {"uid": self.user}, time()
 
 
-# AUTHN = UsernamePasswordMako(None, "login.mako", tl, PASSWD, "authenticated")
 AUTHN_BROKER = AuthnBroker()
 AUTHN_BROKER.add("UNDEFINED", DummyAuthn(None, "username"))
 

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -318,7 +318,7 @@ class TestProvider(object):
                                            path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
 
         parsed = urlparse(resp.message)
         assert "{}://{}{}".format(parsed.scheme, parsed.netloc,
@@ -342,7 +342,7 @@ class TestProvider(object):
                                           path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
 
         aresp = self.cons.parse_response(AuthorizationResponse, resp.message,
                                          sformat="urlencoded")
@@ -352,12 +352,12 @@ class TestProvider(object):
 
     def test_authenticated_hybrid(self):
         _state, location = self.cons.begin(
-                scope="openid email claims_in_id_token",
-                response_type="code id_token",
-                path="http://localhost:8087")
+            scope="openid email claims_in_id_token",
+            response_type="code id_token",
+            path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
 
         part = self.cons.parse_authz(resp.message)
 
@@ -384,7 +384,7 @@ class TestProvider(object):
                                            path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
         parsed = parse_qs(urlparse(resp.message).fragment)
         assert parsed["token_type"][0] == "Bearer"
         assert "access_token" in parsed
@@ -394,7 +394,7 @@ class TestProvider(object):
                                            path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=location.split("?")[1])
+            request=location.split("?")[1])
         parsed = urlparse(resp.message)
         assert "{}://{}{}".format(parsed.scheme, parsed.netloc,
                                   parsed.path) == "http://localhost:8087/authz"
@@ -626,17 +626,17 @@ class TestProvider(object):
                                           path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
 
         self.cons.parse_response(AuthorizationResponse, resp.message,
                                  sformat="urlencoded")
 
         # Construct Access token request
         areq = self.cons.construct_AccessTokenRequest(
-                redirect_uri="http://example.com/authz",
-                client_id="client_1",
-                client_secret='abcdefghijklmnop',
-                state=state)
+            redirect_uri="http://example.com/authz",
+            client_id="client_1",
+            client_secret='abcdefghijklmnop',
+            state=state)
 
         txt = areq.to_urlencoded()
         self.cons.client_secret = 'drickyoughurt'
@@ -657,7 +657,7 @@ class TestProvider(object):
                                            response_type=["code", "token"],
                                            path="http://localhost:8087")
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
 
         parsed = parse_qs(urlparse(resp.message).fragment)
         assert parsed["token_type"][0] == "Bearer"
@@ -702,11 +702,11 @@ class TestProvider(object):
                                           path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
 
         # redirect
         atr = AuthorizationResponse().deserialize(
-                urlparse(resp.message).fragment, "urlencoded")
+            urlparse(resp.message).fragment, "urlencoded")
 
         uir = UserInfoRequest(access_token=atr["access_token"], schema="openid")
 
@@ -750,11 +750,11 @@ class TestProvider(object):
                                           path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
 
         # redirect
         atr = AuthorizationResponse().deserialize(
-                urlparse(resp.message).fragment, "urlencoded")
+            urlparse(resp.message).fragment, "urlencoded")
 
         uir = UserInfoRequest(access_token=atr["access_token"], schema="openid")
 
@@ -772,11 +772,11 @@ class TestProvider(object):
                                           path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
 
         # redirect
         atr = AuthorizationResponse().deserialize(
-                urlparse(resp.message).fragment, "urlencoded")
+            urlparse(resp.message).fragment, "urlencoded")
 
         uir = UserInfoRequest(access_token=atr["access_token"], schema="openid")
 
@@ -815,11 +815,11 @@ class TestProvider(object):
                                           path="http://localhost:8087")
 
         resp = self.provider.authorization_endpoint(
-                request=urlparse(location).query)
+            request=urlparse(location).query)
 
         # redirect
         atr = AuthorizationResponse().deserialize(
-                urlparse(resp.message).fragment, "urlencoded")
+            urlparse(resp.message).fragment, "urlencoded")
 
         uir = UserInfoRequest(schema="openid")
 
@@ -1278,30 +1278,30 @@ class TestProvider(object):
         cid = regresp["client_id"]
 
         areq = AuthorizationRequest(
-                redirect_uri="http://example.org/cb?foo=bar",
-                client_id=cid, scope="openid",
-                response_type="code")
+            redirect_uri="http://example.org/cb?foo=bar",
+            client_id=cid, scope="openid",
+            response_type="code")
 
         self.provider._verify_redirect_uri(areq)
 
     def test_verify_redirect_uri_native_http_localhost(self):
         areq = RegistrationRequest(
-                redirect_uris=["http://localhost/cb"],
-                application_type='native')
+            redirect_uris=["http://localhost/cb"],
+            application_type='native')
 
         self.provider.verify_redirect_uris(areq)
 
     def test_verify_redirect_uri_native_loopback(self):
         areq = RegistrationRequest(
-                redirect_uris=["http://127.0.0.1/cb"],
-                application_type='native')
+            redirect_uris=["http://127.0.0.1/cb"],
+            application_type='native')
 
         self.provider.verify_redirect_uris(areq)
 
     def test_verify_redirect_uri_native_http_non_localhost(self):
         areq = RegistrationRequest(
-                redirect_uris=["http://example.org/cb"],
-                application_type='native')
+            redirect_uris=["http://example.org/cb"],
+            application_type='native')
 
         try:
             self.provider.verify_redirect_uris(areq)
@@ -1310,15 +1310,15 @@ class TestProvider(object):
 
     def test_verify_redirect_uri_native_custom(self):
         areq = RegistrationRequest(
-                redirect_uris=["com.example.app:/oauth2redirect"],
-                application_type='native')
+            redirect_uris=["com.example.app:/oauth2redirect"],
+            application_type='native')
 
         self.provider.verify_redirect_uris(areq)
 
     def test_verify_redirect_uri_native_https(self):
         areq = RegistrationRequest(
-                redirect_uris=["https://example.org/cb"],
-                application_type='native')
+            redirect_uris=["https://example.org/cb"],
+            application_type='native')
 
         try:
             self.provider.verify_redirect_uris(areq)
@@ -1403,27 +1403,27 @@ class TestProvider(object):
     def test_endsession_endpoint_with_id_token_hint(self):
         id_token = self._auth_with_id_token()
         assert self.provider.sdb.get_sids_by_sub(
-                id_token["sub"])  # verify we got valid session
+            id_token["sub"])  # verify we got valid session
 
         id_token_hint = id_token.to_jwt(algorithm="none")
         resp = self.provider.endsession_endpoint(
-                urlencode({"id_token_hint": id_token_hint}))
+            urlencode({"id_token_hint": id_token_hint}))
         assert not self.provider.sdb.get_sids_by_sub(
-                id_token["sub"])  # verify session has been removed
+            id_token["sub"])  # verify session has been removed
         self._assert_cookies_expired(resp.headers)
 
     def test_endsession_endpoint_with_post_logout_redirect_uri(self):
         id_token = self._auth_with_id_token()
         assert self.provider.sdb.get_sids_by_sub(
-                id_token["sub"])  # verify we got valid session
+            id_token["sub"])  # verify we got valid session
 
         post_logout_redirect_uri = \
             CDB[CLIENT_CONFIG["client_id"]]["post_logout_redirect_uris"][0][0]
         resp = self.provider.endsession_endpoint(urlencode(
-                {"post_logout_redirect_uri": post_logout_redirect_uri}))
+            {"post_logout_redirect_uri": post_logout_redirect_uri}))
         assert isinstance(resp, SeeOther)
         assert not self.provider.sdb.get_sids_by_sub(
-                id_token["sub"])  # verify session has been removed
+            id_token["sub"])  # verify session has been removed
         self._assert_cookies_expired(resp.headers)
 
     def test_session_state_in_auth_req_for_session_support(self, session_db_factory):
@@ -1433,7 +1433,7 @@ class TestProvider(object):
                             keyjar=KEYJAR)
 
         provider.capabilities.update({
-                "check_session_iframe": "https://op.example.com/check_session"})
+            "check_session_iframe": "https://op.example.com/check_session"})
 
         req_args = {"scope": ["openid"],
                     "redirect_uri": "http://localhost:8087/authz",
@@ -1442,14 +1442,14 @@ class TestProvider(object):
                     }
         areq = AuthorizationRequest(**req_args)
         resp = provider.authorization_endpoint(
-                request=areq.to_urlencoded())
+            request=areq.to_urlencoded())
         aresp = self.cons.parse_response(AuthorizationResponse, resp.message,
                                          sformat="urlencoded")
         assert "session_state" in aresp
 
     def _assert_cookies_expired(self, http_headers):
         cookies_string = ";".join(
-                [c[1] for c in http_headers if c[0] == "Set-Cookie"])
+            [c[1] for c in http_headers if c[0] == "Set-Cookie"])
         all_cookies = SimpleCookie()
 
         try:
@@ -1469,7 +1469,7 @@ class TestProvider(object):
         state, location = self.cons.begin("openid", "id_token",
                                           path="http://localhost:8087")
         resp = self.provider.authorization_endpoint(
-                request=location.split("?")[1])
+            request=location.split("?")[1])
         aresp = self.cons.parse_response(AuthorizationResponse, resp.message,
                                          sformat="urlencoded")
         return aresp["id_token"]
@@ -1587,4 +1587,3 @@ class TestProvider(object):
         assert resp.status_code == 400
         msg = json.loads(resp.message)
         assert msg["error"] == "invalid_request_uri"
-

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -1572,3 +1572,19 @@ class TestProvider(object):
         resp = self.provider.token_endpoint(request=rareq.to_urlencoded())
         assert resp.headers == [('Pragma', 'no-cache'), ('Cache-Control', 'no-store'),
                                 ('Content-type', 'application/json')]
+
+    def test_authorization_endpoint_faulty_request_uri(self):
+        bib = {"scope": ["openid"],
+               "state": "id-6da9ca0cc23959f5f33e8becd9b08cae",
+               "redirect_uri": "http://localhost:8087/authz",
+               "request_uri": "https://some-non-resolving.hostname.com/request_uri#1234",
+               # faulty request_uri
+               "response_type": ["code"],
+               "client_id": "a1b2c3"}
+
+        arq = AuthorizationRequest(**bib)
+        resp = self.provider.authorization_endpoint(request=arq.to_urlencoded())
+        assert resp.status_code == 400
+        msg = json.loads(resp.message)
+        assert msg["error"] == "invalid_request_uri"
+

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -258,9 +258,6 @@ class TestSessionDB(object):
         self.sdb[sid]['sub'] = 'sub'
         grant = self.sdb[sid]["code"]
 
-        # with mock.patch("time.gmtime", side_effect=[
-        #     time.struct_time((1970, 1, 1, 10, 39, 0, 0, 0, 0)),
-        #     time.struct_time((1970, 1, 1, 10, 40, 0, 0, 0, 0))]):
         dict1 = self.sdb.upgrade_to_token(grant, issue_refresh=True).copy()
         rtoken = dict1["refresh_token"]
         dict2 = self.sdb.refresh_token(rtoken, AREQ['client_id'])

--- a/tests/test_time_util.py
+++ b/tests/test_time_util.py
@@ -62,8 +62,6 @@ def test_modulo_2():
     for i in range(1, 13):
         assert modulo(i, 1, 13) == i
     assert modulo(13, 1, 13) == 1
-    # x = 0.123
-    # assert modulo(13+x, 1, 13) == 1+x
 
 
 def test_parse_duration():
@@ -225,12 +223,6 @@ def test_str_to_time_str_error():
 def test_str_to_time_1():
     t = str_to_time("")
     assert t == 0
-
-
-# def test_utc_time_sans_frac():
-#     t1 = utc_time_sans_frac()
-#     t2 = int("%d" % time.time())
-#     assert t1 != t2
 
 
 def test_before_0():

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -315,9 +315,6 @@ class TestSessionDB(object):
         self.sdb[sid]['sub'] = 'sub'
         grant = self.sdb[sid]["code"]
 
-        # with mock.patch("time.gmtime", side_effect=[
-        #     time.struct_time((1970, 1, 1, 10, 39, 0, 0, 0, 0)),
-        #     time.struct_time((1970, 1, 1, 10, 40, 0, 0, 0, 0))]):
         dict1 = self.sdb.upgrade_to_token(grant, issue_refresh=True).copy()
         rtoken = dict1["refresh_token"]
         dict2 = self.sdb.refresh_token(rtoken, AREQ['client_id'])


### PR DESCRIPTION
return the properly generated `invalid_request_uri` error response
instead of continuing handling the (by then faulty) request which would
return in the following exception:

```
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/oic-0.14.0-py3.6.egg/oic/oic/provider.py",
line 665, in filter_request
    before = req.to_dict()
AttributeError: 'Response' object has no attribute 'to_dict'
```

see: openid-certification/oidctest#10

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [x] The documentation has been updated, if necessary.
---
