### PR TITLE
Fuzz content-type detection

### DIFF
--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -221,7 +221,7 @@ class KeyBundle(object):
         """
         # Check if the content type is the right one.
         try:
-            if response.headers["Content-Type"] != 'application/json':
+            if not response.headers["Content-Type"].startswith('application/json'):
                 logger.warning('Wrong Content_type')
         except KeyError:
             pass


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [x] The documentation has been updated, if necessary.
---
Apply some fuzziness to the `Content-Type` check for JWKS responses, to allow for return values including encoding.

As an example, if the server returns `Content-Type: application/json;charset=utf-8` a warning is display about incorrect Content Type, despite this being a valid option.