### PR TITLE
Add secure and httponly to CookieDealer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,16 @@ The format is based on the [KeepAChangeLog] project.
 - [#588] Switch to defusedxml for XML parsing
 - [#605] Message.c_param dictionary values have to be a ParamDefinition namedtuple type
 
+### Added
+- [#441] CookieDealer now accepts secure and httponly params
+
 [#598]: https://github.com/OpenIDC/pyoidc/issues/598
 [#588]: https://github.com/OpenIDC/pyoidc/issues/588
 [#341]: https://github.com/OpenIDC/pyoidc/issues/341
 [#398]: https://github.com/OpenIDC/pyoidc/issues/398
 [#605]: https://github.com/OpenIDC/pyoidc/pull/605
 [#605]: https://github.com/OpenIDC/pyoidc/issues/607
+[#441]: https://github.com/OpenIDC/pyoidc/issues/441
 
 ## 0.15.1 [2019-01-31]
 

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -64,6 +64,53 @@ class TestCookieDealer(object):
                                                                "Foobar")
 
         assert (value, typ) == (cookie_value, cookie_typ)
+        t = SimpleCookie()
+        t.load(kaka[1])
+        morsel = t['Foobar']
+        assert morsel['secure']
+        assert morsel['httponly']
+
+    def test_create_cookie_value_no_httponly(self):
+        cookie_value = "Something to pass along"
+        cookie_typ = "sso"
+        cookie_name = "Foobar"
+
+        class DummyServer():
+            def __init__(self):
+                self.symkey = b"0123456789012345"
+        cookie_dealer = CookieDealer(DummyServer(), httponly=False)
+        kaka = cookie_dealer.create_cookie(cookie_value, cookie_typ,
+                                           cookie_name)
+        value, timestamp, typ = cookie_dealer.get_cookie_value(kaka[1],
+                                                               "Foobar")
+
+        assert (value, typ) == (cookie_value, cookie_typ)
+        t = SimpleCookie()
+        t.load(kaka[1])
+        morsel = t['Foobar']
+        assert morsel['secure']
+        assert not morsel['httponly']
+
+    def test_create_cookie_value_no_secure(self):
+        cookie_value = "Something to pass along"
+        cookie_typ = "sso"
+        cookie_name = "Foobar"
+
+        class DummyServer():
+            def __init__(self):
+                self.symkey = b"0123456789012345"
+        cookie_dealer = CookieDealer(DummyServer(), secure=False)
+        kaka = cookie_dealer.create_cookie(cookie_value, cookie_typ,
+                                           cookie_name)
+        value, timestamp, typ = cookie_dealer.get_cookie_value(kaka[1],
+                                                               "Foobar")
+
+        assert (value, typ) == (cookie_value, cookie_typ)
+        t = SimpleCookie()
+        t.load(kaka[1])
+        morsel = t['Foobar']
+        assert not morsel['secure']
+        assert morsel['httponly']
 
     def test_delete_cookie(self, cookie_dealer):
         cookie_name = "Foobar"


### PR DESCRIPTION
Close #441

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
