### PR TITLE
Fix: Grant storage for access tokens response subclasses

### DIFF
--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -554,7 +554,7 @@ class Client(PBase):
 
         self.store_response(resp, info)
 
-        if resp.type() in ["AuthorizationResponse", "AccessTokenResponse"]:
+        if isinstance(resp, (AuthorizationResponse, AccessTokenResponse)):
             try:
                 _state = resp["state"]
             except (AttributeError, KeyError):

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -34,6 +34,7 @@ from oic.oic.message import OpenIDSchema
 from oic.oic.message import RefreshAccessTokenRequest
 from oic.oic.message import RefreshSessionRequest
 from oic.oic.message import RegistrationRequest
+from oic.oic.message import SINGLE_OPTIONAL_STRING
 from oic.oic.message import UserInfoRequest
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from oic.utils.keyio import KeyBundle
@@ -142,6 +143,41 @@ class TestClient(object):
         assert isinstance(resp, AccessTokenResponse)
         assert _eq(resp.keys(),
                    ['token_type', 'state', 'access_token', 'scope'])
+
+    def test_access_token_request_with_custom_response_class(self):
+        args = {"response_type": ["code"],
+                "scope": ["openid"]}
+        r = self.client.do_authorization_request(state="state0",
+                                                 request_args=args)
+
+        self.client.parse_response(AuthorizationResponse, r.headers["location"],
+                                   sformat="urlencoded")
+
+        # AccessTokenResponse wrapper class
+        class AccessTokenResponseWrapper(AccessTokenResponse):
+            c_param = AccessTokenResponse.c_param.copy()
+            c_param.update({"raw_id_token": SINGLE_OPTIONAL_STRING})
+
+            def __init__(self, *args, **kwargs):
+                super(AccessTokenResponseWrapper, self).__init__(*args, **kwargs)
+                self["raw_id_token"] = None
+
+            def verify(self, **kwargs):
+                if "id_token" in self:
+                    self["raw_id_token"] = self["id_token"]
+                return super(AccessTokenResponseWrapper, self).verify(**kwargs)
+
+        resp = \
+            self.client.do_access_token_request(scope="openid",
+                                                state="state0",
+                                                response_cls=AccessTokenResponseWrapper)
+
+        assert isinstance(resp, AccessTokenResponse)
+        assert isinstance(resp, AccessTokenResponseWrapper)
+        assert _eq(resp.keys(),
+                   ['token_type', 'state', 'access_token', 'scope',
+                    'raw_id_token'])
+        assert len(self.client.grant["state0"].tokens) == 1
 
     def test_do_user_info_request(self):
         resp = AuthorizationResponse(code="code", state="state")

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -20,6 +20,7 @@ from oic.oic import Server
 from oic.oic import Token
 from oic.oic import scope2claims
 from oic.oic.message import SCOPE2CLAIMS
+from oic.oic.message import SINGLE_OPTIONAL_STRING
 from oic.oic.message import AccessTokenRequest
 from oic.oic.message import AccessTokenResponse
 from oic.oic.message import AuthorizationRequest
@@ -34,7 +35,6 @@ from oic.oic.message import OpenIDSchema
 from oic.oic.message import RefreshAccessTokenRequest
 from oic.oic.message import RefreshSessionRequest
 from oic.oic.message import RegistrationRequest
-from oic.oic.message import SINGLE_OPTIONAL_STRING
 from oic.oic.message import UserInfoRequest
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from oic.utils.keyio import KeyBundle


### PR DESCRIPTION
- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
It fixes the issue we discovered on #608 