### PR TITLE
`client_management.py` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on the [KeepAChangeLog] project.
 - [#598] Move alabaster from runtime dependencies to docs
 - [#398] Do not echo cookies that do not belong to us
 - [#607] Fixed key recovery on encryption of payload
+- [#618] Prettified `client_management.py` CLI and wrapped it as
+         a setup.py console script `oic-client-management`
 
 ### Changed
 - [#578] Dropped python 2.7 support
@@ -30,6 +32,7 @@ The format is based on the [KeepAChangeLog] project.
 [#607]: https://github.com/OpenIDC/pyoidc/issues/607
 [#441]: https://github.com/OpenIDC/pyoidc/issues/441
 [#612]: https://github.com/OpenIDC/pyoidc/pull/612
+[#618]: https://github.com/OpenIDC/pyoidc/pull/618
 
 ## 0.15.1 [2019-01-31]
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ class PyTest(TestCommand):
 
 tests_requires = ['responses', 'testfixtures', 'pytest', 'freezegun']
 
-version = ''
 with open('src/oic/__init__.py', 'r') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                         fd.read(), re.MULTILINE).group(1)

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,11 @@ setup(
         "oic", "oic/oauth2", "oic/oic", "oic/utils", "oic/utils/authn",
         "oic/utils/userinfo", 'oic/utils/rp', 'oic/extension'
     ],
+    entry_points={
+        'console_scripts': [
+            'oic-client-management = oic.utils.client_management:run'
+        ]
+    },
     package_dir={"": "src"},
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/src/oic/utils/client_management.py
+++ b/src/oic/utils/client_management.py
@@ -137,7 +137,7 @@ class CDB(BaseClientDatabase):
         fp.close()
 
 
-if __name__ == "__main__":
+def run():
     parser = argparse.ArgumentParser()
     parser.add_argument('-l', '--list', dest='list', action='store_true',
                         help="List all client_ids")
@@ -185,3 +185,7 @@ if __name__ == "__main__":
         cdb.load(args.input_file)
     elif args.output_file:
         cdb.dump(args.output_file)
+
+
+if __name__ == '__main__':
+    run()

--- a/src/oic/utils/client_management.py
+++ b/src/oic/utils/client_management.py
@@ -59,7 +59,7 @@ class CDB(BaseClientDatabase):
         return self.cdb.items()
 
     def create(self, redirect_uris=None, policy_uri="", logo_uri="",
-               jwks_uri="", **kwargs):
+               jwks_uri=""):
         if redirect_uris is None:
             print(
                 'Enter redirect_uris one at the time, end with a blank line: ')
@@ -169,7 +169,8 @@ def run():
     cdb = CDB(args.filename)
 
     if args.list:
-        print(cdb.keys())
+        for client_id in list(cdb.keys()):
+            print(client_id)
     elif args.client_id:
         if args.delete:
             del cdb[args.client_id]

--- a/src/oic/utils/client_management.py
+++ b/src/oic/utils/client_management.py
@@ -139,26 +139,26 @@ class CDB(BaseClientDatabase):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('-l', dest='list', action='store_true',
-                        help="list all client_ids")
-    parser.add_argument('-d', dest='delete', action='store_true',
-                        help="delete the entity with the given client_id")
-    parser.add_argument('-c', dest='create', action='store_true',
-                        help=("create a new client, returns the stored "
+    parser.add_argument('-l', '--list', dest='list', action='store_true',
+                        help="List all client_ids")
+    parser.add_argument('-d', '--delete', dest='delete', action='store_true',
+                        help="Delete the entity with the given client_id")
+    parser.add_argument('-c', '--create', dest='create', action='store_true',
+                        help=("Create a new client, returns the stored "
                               "information"))
-    parser.add_argument('-s', dest='show', action='store_true',
-                        help=("show information connected to a specific"
+    parser.add_argument('-s', '--show', dest='show', action='store_true',
+                        help=("Show information connected to a specific"
                               "client_id"))
-    parser.add_argument('-i', dest='client_id',
-                        help="a client_id on which to do an action")
-    parser.add_argument('-r', dest='replace',
-                        help=("information that should replace what's there"
+    parser.add_argument('-i', '--client-id', dest='client_id',
+                        help="A client_id on which to do an action")
+    parser.add_argument('-r', '--replace', dest='replace',
+                        help=("Information that should replace what's there"
                               "about a specific client_id"))
-    parser.add_argument('-I', dest='input_file',
+    parser.add_argument('-I', '--input-file', dest='input_file',
                         help="Import client information from a file")
-    parser.add_argument('-D', dest='output_file',
+    parser.add_argument('-D', '--output-file', dest='output_file',
                         help="Dump client information to a file")
-    parser.add_argument('-R', dest="reset", action='store_true',
+    parser.add_argument('-R', '--reset', dest="reset", action='store_true',
                         help="Reset the database == removing all registrations")
     parser.add_argument(dest="filename")
     args = parser.parse_args()

--- a/src/oic/utils/clientdb.py
+++ b/src/oic/utils/clientdb.py
@@ -1,4 +1,4 @@
-"""Client managament databases."""
+"""Client management databases."""
 from abc import ABCMeta
 from abc import abstractmethod
 from urllib.parse import quote

--- a/tests/utils/test_client_management_run.py
+++ b/tests/utils/test_client_management_run.py
@@ -21,7 +21,6 @@ class TestClientManagementRun(object):
     def test_help_prints_usage_instructions(self):
         result = run(CLI_INVOCATION + '--help', shell=True,
                      stdout=PIPE, stderr=PIPE)
-        assert result.returncode is 0
         assert result.stdout.decode().startswith('usage: ')
         assert result.stderr.decode() == ''
 
@@ -29,7 +28,6 @@ class TestClientManagementRun(object):
         for list_option_form in ('-l', '--list'):
             result = run(CLI_INVOCATION + list_option_form + ' ' + db_file_path,
                          shell=True, stdout=PIPE, stderr=STDOUT)
-            assert result.returncode is 0
             assert result.stdout.decode() == ''
 
     def test_list_option_with_1_client_id_in_db(self, db_file_path):
@@ -45,7 +43,6 @@ class TestClientManagementRun(object):
         for list_option_form in ('-l', '--list'):
             result = run(CLI_INVOCATION + list_option_form + ' ' + db_file_path,
                          shell=True, stdout=PIPE, stderr=STDOUT)
-            assert result.returncode is 0
             assert result.stdout.decode().splitlines() == ['the_first']
 
     def test_list_option_with_2_client_ids_in_db(self, db_file_path):
@@ -65,5 +62,4 @@ class TestClientManagementRun(object):
         for list_option_form in ('-l', '--list'):
             result = run(CLI_INVOCATION + list_option_form + ' ' + db_file_path,
                          shell=True, stdout=PIPE, stderr=STDOUT)
-            assert result.returncode is 0
             assert set(result.stdout.decode().splitlines()) == client_ids

--- a/tests/utils/test_client_management_run.py
+++ b/tests/utils/test_client_management_run.py
@@ -1,5 +1,6 @@
 import tempfile
 from subprocess import run, STDOUT, PIPE
+from sys import executable as python_executable
 
 import pytest
 
@@ -7,7 +8,7 @@ import oic.utils.client_management
 from oic.utils.client_management import CDB, pack_redirect_uri
 
 CLI_PATH = oic.utils.client_management.__file__
-CLI_INVOCATION = 'python {} '.format(CLI_PATH)
+CLI_INVOCATION = '{} {} '.format(python_executable, CLI_PATH)
 
 
 @pytest.fixture

--- a/tests/utils/test_client_management_run.py
+++ b/tests/utils/test_client_management_run.py
@@ -1,0 +1,69 @@
+import tempfile
+from subprocess import run, STDOUT, PIPE
+
+import pytest
+
+import oic.utils.client_management
+from oic.utils.client_management import CDB, pack_redirect_uri
+
+CLI_PATH = oic.utils.client_management.__file__
+CLI_INVOCATION = 'python {} '.format(CLI_PATH)
+
+
+@pytest.fixture
+def db_file_path():
+    db_file = tempfile.NamedTemporaryFile(delete=True)
+    db_file.close()
+    return db_file.name
+
+
+class TestClientManagementRun(object):
+    def test_help_prints_usage_instructions(self):
+        result = run(CLI_INVOCATION + '--help', shell=True,
+                     stdout=PIPE, stderr=PIPE)
+        assert result.returncode is 0
+        assert result.stdout.decode().startswith('usage: ')
+        assert result.stderr.decode() == ''
+
+    def test_list_option_with_empty_db_lists_nothing(self, db_file_path):
+        for list_option_form in ('-l', '--list'):
+            result = run(CLI_INVOCATION + list_option_form + ' ' + db_file_path,
+                         shell=True, stdout=PIPE, stderr=STDOUT)
+            assert result.returncode is 0
+            assert result.stdout.decode() == ''
+
+    def test_list_option_with_1_client_id_in_db(self, db_file_path):
+        client_db = CDB(db_file_path)
+        client_db.cdb['the_first'] = {
+            'client_secret': 'hardToGuess',
+            'client_id': 'the_first',
+            'client_salt': 'saltedAndReady!',
+            'redirect_uris': pack_redirect_uri(['file:///dev/null'])
+        }
+        client_db.cdb.close()
+
+        for list_option_form in ('-l', '--list'):
+            result = run(CLI_INVOCATION + list_option_form + ' ' + db_file_path,
+                         shell=True, stdout=PIPE, stderr=STDOUT)
+            assert result.returncode is 0
+            assert result.stdout.decode().splitlines() == ['the_first']
+
+    def test_list_option_with_2_client_ids_in_db(self, db_file_path):
+        client_ids = {'the_first', 'the_2nd'}
+
+        client_db = CDB(db_file_path)
+        for client_id in client_ids:
+            client_db.cdb[client_id] = {
+                'client_secret': 'hardToGuess',
+                'client_id': client_id,
+                'client_salt': 'saltedAndReady!',
+                'redirect_uris': pack_redirect_uri(['file:///dev/null',
+                                                   'http://localhost:1337/'])
+            }
+        client_db.cdb.close()
+
+        for list_option_form in ('-l', '--list'):
+            result = run(CLI_INVOCATION + list_option_form + ' ' + db_file_path,
+                         shell=True, stdout=PIPE, stderr=STDOUT)
+            assert result.returncode is 0
+            assert set(result.stdout.decode().splitlines()) == client_ids


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [x] The documentation has been updated, if necessary.
---

Hi PyOIDC maintainers! It seems to me that this `src/oic/utils/client_management.py` script is key to getting examples running for us new-comers. :) Here's a PR that lifts it up in 3 ways:
1. Extends the command-line interface with some user-friendly long-form option names
2. Fixes a bug where `-l` (or `--list`) would output some "KeysView" memory reference instead of client IDs
3. Adds it to `setup.py` to be installed as a Python environment-local `oic-client-management` CLI tool (invoking it with `python full-filepath/to/script.py ...` still works as before of course)


## Before

![screenshot 2019-02-25 at 13 24 26](https://user-images.githubusercontent.com/786326/53351833-fd6d1800-3921-11e9-888f-f2009c9ebe5e.png)


## After

![screenshot 2019-02-25 at 16 51 23](https://user-images.githubusercontent.com/786326/53352150-8f752080-3922-11e9-9df8-7ec83c3e7294.png)
