### PR TITLE
Deprecate `bearer_auth` helper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on the [KeepAChangeLog] project.
         making it into a stand-alone example easy for beginners to take on 
 - [#624] token_endpoint implementation and kwargs have been changed
 - [#629] Duplicated methods in oic.oic classes were removed.
+- [#642] Deprecated `bearer_auth` method.
 
 ### Added
 - [#441] CookieDealer now accepts secure and httponly params
@@ -44,6 +45,7 @@ The format is based on the [KeepAChangeLog] project.
 [#629]: https://github.com/OpenIDC/pyoidc/issues/629
 [#615]: https://github.com/OpenIDC/pyoidc/issues/615
 [#640]: https://github.com/OpenIDC/pyoidc/issues/640
+[#642]: https://github.com/OpenIDC/pyoidc/pull/642
 
 ## 0.15.1 [2019-01-31]
 

--- a/src/oic/oic/claims_provider.py
+++ b/src/oic/oic/claims_provider.py
@@ -13,7 +13,6 @@ from oic.oic.message import Claims
 from oic.oic.message import OpenIDSchema
 from oic.oic.provider import Endpoint
 from oic.oic.provider import Provider
-from oic.utils.authn.client import bearer_auth
 from oic.utils.http_util import Response
 from oic.utils.keyio import KeyJar
 from oic.utils.sanitize import sanitize
@@ -137,10 +136,8 @@ class ClaimsServer(Provider):
         _log_info("Claims_info_endpoint query: '%s'" % sanitize(request))
 
         ucreq = self.srvmethod.parse_userinfo_claims_request(request)
-
-        # Bearer header or body
-        access_token = bearer_auth(ucreq, authn)
-        uiresp = OpenIDSchema(**self.info_store[access_token])
+        # Access_token is mandatory in UserInfoClaimsRequest
+        uiresp = OpenIDSchema(**self.info_store[ucreq['access_token']])
 
         _log_info("returning: %s" % sanitize(uiresp.to_dict()))
         return Response(uiresp.to_json(), content="application/json")

--- a/src/oic/utils/authn/client.py
+++ b/src/oic/utils/authn/client.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import warnings
 from urllib.parse import quote_plus
 
 from jwkest import Invalid
@@ -257,6 +258,7 @@ def bearer_auth(req, authn):
     :param authn:
     :return:
     """
+    warnings.warn("`bearer_auth` is deprecated.", DeprecationWarning, stacklevel=2)
     try:
         return req["access_token"]
     except KeyError:

--- a/tests/test_claims_provider.py
+++ b/tests/test_claims_provider.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-
-# pylint: disable=missing-docstring,no-self-use
 import os
 from urllib.parse import parse_qs
 
@@ -11,6 +8,7 @@ from oic.oic.claims_provider import ClaimsClient
 from oic.oic.claims_provider import ClaimsServer
 from oic.oic.claims_provider import UserClaimsRequest
 from oic.oic.claims_provider import UserClaimsResponse
+from oic.oic.claims_provider import UserInfoClaimsRequest
 from oic.oic.message import OpenIDSchema
 from oic.utils.authn.client import verify_client
 from oic.utils.claims import ClaimsMode
@@ -128,6 +126,18 @@ class TestClaimsServer(object):
 
         assert _eq(ucr["claims_names"], ["gender", "birthdate"])
         assert "jwt" in ucr
+
+    def test_claims_info_endpoint(self):
+        self.srv.info_store['access_token'] = {'sub': 'some_sub',
+                                               'gender': 'neutral',
+                                               'birthdate': 'someday',
+                                               'claims_names': ['gender', 'birthdate']}
+        req = UserInfoClaimsRequest(access_token='access_token')
+        resp = self.srv.claims_info_endpoint(req.to_urlencoded(), "")
+
+        ucr = UserClaimsResponse().deserialize(resp.message, "json")
+        ucr.verify()
+        assert _eq(ucr["claims_names"], ["gender", "birthdate"])
 
     @pytest.fixture(scope="session")
     def keyjar(self):


### PR DESCRIPTION
It was used on only one place and contains `assert`.

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
---
