### PR TITLE
Update Jinja2 dependency for simple_op2

### DIFF
--- a/oidc_example/simple_op/requirements.txt
+++ b/oidc_example/simple_op/requirements.txt
@@ -1,4 +1,4 @@
 cherrypy==3.2.4
 pyaml==15.03.1
-Jinja2==2.7.3
+Jinja2==2.10.1
 yubico-client==1.9.1


### PR DESCRIPTION
Older versions have a security issue and github complains about it.

See CVE-2019-8341.

It does not really affect pyoidc, as the bug is only in SandboxedEnvironment which isn't used.