### PR TITLE
Add bandit to the quality tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ help:
 	@echo "  test       to run the tests"
 	@echo "  isort      to sort imports"
 	@echo "  blacken    to format the code"
+	@echo "  bandit     to run some simple security checkers"
 .PHONY: help
 
 clean:
@@ -54,6 +55,10 @@ blacken:
 check-black:
 	@pipenv run black src/ --check
 .PHONY: blacken check-black
+
+bandit:
+	@pipenv run bandit -a file -r src/ oauth_example/ oidc_example/ 
+.PHONY: bandit
 
 check-pylama:
 	@pipenv run pylama $(OICDIR) $(TESTDIR)

--- a/oidc_example/op3/server.py
+++ b/oidc_example/op3/server.py
@@ -10,6 +10,8 @@ import sys
 import traceback
 import argparse
 import importlib
+import logging
+
 from mako.lookup import TemplateLookup
 
 from oic import rndstr
@@ -243,7 +245,7 @@ class Application(object):
              ]}
 
         """
-        print '\n in meta-info'
+        print('\n in meta-info')
         pass
 
     def webfinger(self, environ, start_response):
@@ -275,7 +277,7 @@ class Application(object):
         """
         path = environ.get('PATH_INFO', '').lstrip('/')
 
-        print 'start_response: ', start_response
+        print('start_response: ', start_response)
 
         if path == "robots.txt":
             return static(self, environ, start_response, "static/robots.txt")
@@ -470,7 +472,7 @@ if __name__ == '__main__':
     server = wsgiserver.CherryPyWSGIServer(('0.0.0.0', config.PORT), _app.application)
     server.ssl_adapter = BuiltinSSLAdapter(config.SERVER_CERT, config.SERVER_KEY)
 
-    print "OIDC Provider server started (issuer={}, port={})".format(config.ISSUER, config.PORT)
+    print("OIDC Provider server started (issuer={}, port={})".format(config.ISSUER, config.PORT))
 
     try:
         server.start()

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'develop': ["cherrypy==3.2.4", "pyOpenSSL"],
         'testing': tests_requires,
         'docs': ['Sphinx', 'sphinx-autobuild', 'alabaster'],
-        'quality': ['pylama', 'isort', 'eradicate', 'mypy', 'black'],
+        'quality': ['pylama', 'isort', 'eradicate', 'mypy', 'black', 'bandit'],
         'ldap_authn': ['pyldap'],
     },
     install_requires=[


### PR DESCRIPTION
Adding the bandit tool to the toolbox.
https://github.com/PyCQA/bandit

And fix some trivial py3 syntax errors in the op3 example so it doesn't blow up right away when running the bandit.

As we have some security sensitive code here, we probably should run some basic scanner like that to catch the simpler issues. Its not good enough for the CI yet, but give it a try.

Running it only on code & examples, as the tests do not need and cannot be secure.