### PR TITLE
Removed deprecated request/response_cls kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on the [KeepAChangeLog] project.
 ### Fixed
 - [#669] Install as PEP561 compliant package
 
+### Removed
+- [#671] Removed deprecated request/response_cls kwargs from Provider/Client methods
+
+[#671]: https://github.com/OpenIDC/pyoidc/pull/XXX
 [#669]: https://github.com/OpenIDC/pyoidc/issues/669
 
 ## 1.0.0 [2019-06-19]

--- a/src/oic/extension/client.py
+++ b/src/oic/extension/client.py
@@ -2,7 +2,6 @@ import hashlib
 import logging
 import random
 import string
-import warnings
 
 from jwkest import b64e
 
@@ -160,33 +159,15 @@ class Client(oauth2.Client):
 
     def do_client_registration(
         self,
-        request=None,
         body_type="",
         method="GET",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         **kwargs
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("registration_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type(
-                "registration_endpoint"
-            )
+        request = self.message_factory.get_request_type("registration_endpoint")
+        response_cls = self.message_factory.get_response_type("registration_endpoint")
         return self.do_op(
             request=request,
             body_type=body_type,
@@ -200,31 +181,15 @@ class Client(oauth2.Client):
 
     def do_client_read_request(
         self,
-        request=None,
         body_type="",
         method="GET",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         **kwargs
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("update_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type("update_endpoint")
+        request = self.message_factory.get_request_type("update_endpoint")
+        response_cls = self.message_factory.get_response_type("update_endpoint")
         return self.do_op(
             request=request,
             body_type=body_type,
@@ -238,31 +203,15 @@ class Client(oauth2.Client):
 
     def do_client_update_request(
         self,
-        request=None,
         body_type="",
         method="PUT",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         **kwargs
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("update_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type("update_endpoint")
+        request = self.message_factory.get_request_type("update_endpoint")
+        response_cls = self.message_factory.get_response_type("update_endpoint")
         return self.do_op(
             request=request,
             body_type=body_type,
@@ -276,31 +225,15 @@ class Client(oauth2.Client):
 
     def do_client_delete_request(
         self,
-        request=None,
         body_type="",
         method="DELETE",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         **kwargs
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("delete_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type("delete_endpoint")
+        request = self.message_factory.get_request_type("delete_endpoint")
+        response_cls = self.message_factory.get_response_type("delete_endpoint")
         return self.do_op(
             request=request,
             body_type=body_type,
@@ -314,33 +247,15 @@ class Client(oauth2.Client):
 
     def do_token_introspection(
         self,
-        request=None,
         body_type="json",
         method="POST",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         **kwargs
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("introspection_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type(
-                "introspection_endpoint"
-            )
+        request = self.message_factory.get_request_type("introspection_endpoint")
+        response_cls = self.message_factory.get_response_type("introspection_endpoint")
         return self.do_op(
             request=request,
             body_type=body_type,
@@ -354,31 +269,15 @@ class Client(oauth2.Client):
 
     def do_token_revocation(
         self,
-        request=None,
         body_type="",
         method="POST",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         **kwargs
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("revocation_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type("revocation_endpoint")
+        request = self.message_factory.get_request_type("revocation_endpoint")
+        response_cls = self.message_factory.get_response_type("revocation_endpoint")
         return self.do_op(
             request=request,
             body_type=body_type,
@@ -419,48 +318,26 @@ class Client(oauth2.Client):
 
     def do_authorization_request(
         self,
-        request=None,
         state="",
         body_type="",
         method="GET",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         **kwargs
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("authorization_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type(
-                "authorization_endpoint"
-            )
         if "code_challenge" in self.config and self.config["code_challenge"]:
             _args, code_verifier = self.add_code_challenge()
             request_args.update(_args)
 
         oauth2.Client.do_authorization_request(
             self,
-            request=request,
             state=state,
             body_type=body_type,
             method=method,
             request_args=request_args,
             extra_args=extra_args,
             http_args=http_args,
-            response_cls=response_cls,
             **kwargs
         )
 

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from typing import Any  # noqa - This is used for MyPy
 from typing import Dict
 from typing import List  # noqa - This is used for MyPy
@@ -751,36 +750,17 @@ class Client(PBase):
 
     def do_authorization_request(
         self,
-        request=None,
         state="",
         body_type="",
         method="GET",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         **kwargs
     ) -> AuthorizationResponse:
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            # TODO: This can be moved to the call once we remove the kwarg
-            request = self.message_factory.get_request_type("authorization_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            # TODO: This can be moved to the call once we remove the kwarg
-            response_cls = self.message_factory.get_response_type(
-                "authorization_endpoint"
-            )
+
+        request = self.message_factory.get_request_type("authorization_endpoint")
+        response_cls = self.message_factory.get_response_type("authorization_endpoint")
 
         if state:
             try:
@@ -828,7 +808,6 @@ class Client(PBase):
 
     def do_access_token_request(
         self,
-        request=None,
         scope: str = "",
         state: str = "",
         body_type: ENCODINGS = "json",
@@ -836,28 +815,12 @@ class Client(PBase):
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         authn_method="",
         **kwargs
     ) -> AccessTokenResponse:
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            # TODO: This can be moved to the call once we remove the kwarg
-            request = self.message_factory.get_request_type("token_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            # TODO: This can be moved to the call once we remove the kwarg
-            response_cls = self.message_factory.get_response_type("token_endpoint")
+
+        request = self.message_factory.get_request_type("token_endpoint")
+        response_cls = self.message_factory.get_response_type("token_endpoint")
 
         kwargs["authn_endpoint"] = "token"
         # method is default POST
@@ -898,35 +861,18 @@ class Client(PBase):
 
     def do_access_token_refresh(
         self,
-        request=None,
         state: str = "",
         body_type: ENCODINGS = "json",
         method="POST",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         authn_method="",
         **kwargs
     ) -> AccessTokenResponse:
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            # TODO: This can be moved to the call once we remove the kwarg
-            request = self.message_factory.get_request_type("refresh_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            # TODO: This can be moved to the call once we remove the kwarg
-            response_cls = self.message_factory.get_response_type("refresh_endpoint")
+
+        request = self.message_factory.get_request_type("refresh_endpoint")
+        response_cls = self.message_factory.get_response_type("refresh_endpoint")
 
         token = self.get_token(also_expired=True, state=state, **kwargs)
         kwargs["authn_endpoint"] = "refresh"
@@ -1109,19 +1055,10 @@ class Client(PBase):
         issuer: str,
         keys: bool = True,
         endpoints: bool = True,
-        response_cls: Type[ASConfigurationResponse] = None,
         serv_pattern: str = OIDCONF_PATTERN,
     ) -> ASConfigurationResponse:
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type(
-                "configuration_endpoint"
-            )
+
+        response_cls = self.message_factory.get_response_type("configuration_endpoint")
         if issuer.endswith("/"):
             _issuer = issuer[:-1]
         else:
@@ -1181,19 +1118,9 @@ class Server(PBase):
         return req
 
     def parse_authorization_request(
-        self,
-        request: Type[AuthorizationRequest] = None,
-        url: str = None,
-        query: dict = None,
+        self, url: str = None, query: dict = None
     ) -> AuthorizationRequest:
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("authorization_endpoint")
+        request = self.message_factory.get_request_type("authorization_endpoint")
         return self.parse_url_request(request, url, query)
 
     def parse_jwt_request(
@@ -1220,28 +1147,12 @@ class Server(PBase):
         req.verify()
         return req
 
-    def parse_token_request(
-        self, request: Type[AccessTokenRequest] = None, body: str = None
-    ) -> AccessTokenRequest:
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("token_endpoint")
+    def parse_token_request(self, body: str = None) -> AccessTokenRequest:
+        request = self.message_factory.get_request_type("token_endpoint")
         return self.parse_body_request(request, body)
 
     def parse_refresh_token_request(
-        self, request: Type[RefreshAccessTokenRequest] = None, body: str = None
+        self, body: str = None
     ) -> RefreshAccessTokenRequest:
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("refresh_endpoint")
+        request = self.message_factory.get_request_type("refresh_endpoint")
         return self.parse_body_request(request, body)

--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -393,23 +393,15 @@ class Provider(object):
             return False
         return True
 
-    def provider_features(self, pcr_class=None, provider_config=None):
+    def provider_features(self, provider_config=None):
         """
         Present what the server capabilities are.
 
-        :param pcr_class:
         :return: ProviderConfigurationResponse instance
         """
-        if pcr_class is not None:
-            warnings.warn(
-                "`pcr_class` is deprecated, please use `message_factory`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            pcr_class = self.server.message_factory.get_response_type(
-                "configuration_endpoint"
-            )
+        pcr_class = self.server.message_factory.get_response_type(
+            "configuration_endpoint"
+        )
 
         _provider_info = pcr_class(**self.default_capabilities)
         _provider_info["scopes_supported"] = self.scopes
@@ -429,24 +421,16 @@ class Provider(object):
 
         return _provider_info
 
-    def create_providerinfo(self, pcr_class=None, setup=None):
+    def create_providerinfo(self, setup=None):
         """
         Dynamically create the provider info response.
 
-        :param pcr_class:
         :param setup:
         :return:
         """
-        if pcr_class is not None:
-            warnings.warn(
-                "Passing `pcr_class` is deprecated. Please use `message_factory.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            pcr_class = self.server.message_factory.get_response_type(
-                "configuration_endpoint"
-            )
+        pcr_class = self.server.message_factory.get_response_type(
+            "configuration_endpoint"
+        )
         _provider_info = copy.deepcopy(self.capabilities.to_dict())
 
         if self.jwks_uri and self.keyjar:
@@ -574,30 +558,21 @@ class Provider(object):
     def filter_request(self, req):
         return req
 
-    def auth_init(self, request, request_class=None):
+    def auth_init(self, request):
         """
         Start the authentication process.
 
         :param request: The AuthorizationRequest
         :return:
         """
-        if request_class is not None:
-            warnings.warn(
-                "Passing `request_class` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request_class = self.server.message_factory.get_request_type(
-                "authorization_endpoint"
-            )
+        request_class = self.server.message_factory.get_request_type(
+            "authorization_endpoint"
+        )
         logger.debug("Request: '%s'" % sanitize(request))
         # Same serialization used for GET and POST
 
         try:
-            areq = self.server.parse_authorization_request(
-                request=request_class, query=request
-            )
+            areq = self.server.parse_authorization_request(query=request)
         except (MissingRequiredValue, MissingRequiredAttribute, AuthzError) as err:
             logger.debug("%s" % err)
             areq = request_class()

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -43,7 +43,6 @@ from oic.oauth2.message import Message
 from oic.oauth2.message import MessageFactory
 from oic.oauth2.util import get_or_post
 from oic.oic.message import SCOPE2CLAIMS
-from oic.oic.message import AccessTokenRequest
 from oic.oic.message import AccessTokenResponse
 from oic.oic.message import AuthorizationErrorResponse
 from oic.oic.message import AuthorizationRequest
@@ -57,7 +56,6 @@ from oic.oic.message import JasonWebToken
 from oic.oic.message import OIDCMessageFactory
 from oic.oic.message import OpenIDRequest
 from oic.oic.message import OpenIDSchema
-from oic.oic.message import RefreshAccessTokenRequest
 from oic.oic.message import RefreshSessionRequest
 from oic.oic.message import RegistrationRequest
 from oic.oic.message import RegistrationResponse
@@ -636,28 +634,14 @@ class Client(oauth2.Client):
 
     def do_authorization_request(
         self,
-        request=None,
         state="",
         body_type="",
         method="GET",
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         **kwargs
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         algs = self.sign_enc_algs("id_token")
 
         if "code_challenge" in self.config:
@@ -665,20 +649,17 @@ class Client(oauth2.Client):
             request_args.update(_args)
 
         return super().do_authorization_request(
-            request=request,
             state=state,
             body_type=body_type,
             method=method,
             request_args=request_args,
             extra_args=extra_args,
             http_args=http_args,
-            response_cls=response_cls,
             algs=algs,
         )
 
     def do_access_token_request(
         self,
-        request=None,
         scope="",
         state="",
         body_type="json",
@@ -686,25 +667,10 @@ class Client(oauth2.Client):
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
         authn_method="client_secret_basic",
         **kwargs
     ):
-
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         atr = super().do_access_token_request(
-            request=request,
             scope=scope,
             state=state,
             body_type=body_type,
@@ -712,7 +678,6 @@ class Client(oauth2.Client):
             request_args=request_args,
             extra_args=extra_args,
             http_args=http_args,
-            response_cls=response_cls,
             authn_method=authn_method,
             **kwargs
         )
@@ -730,7 +695,6 @@ class Client(oauth2.Client):
 
     def do_registration_request(
         self,
-        request=None,
         scope="",
         state="",
         body_type="json",
@@ -738,17 +702,8 @@ class Client(oauth2.Client):
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
     ):
-
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("registration_endpoint")
+        request = self.message_factory.get_request_type("registration_endpoint")
         url, body, ht_args, csi = self.request_info(
             request,
             method=method,
@@ -763,16 +718,7 @@ class Client(oauth2.Client):
         else:
             http_args.update(http_args)
 
-        if response_cls is None:
-            response_cls = self.message_factory.get_response_type(
-                "registration_endpoint"
-            )
-        else:
-            warnings.warn(
-                "Passing `response_cls` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        response_cls = self.message_factory.get_response_type("registration_endpoint")
         response = self.request_and_return(
             url, response_cls, method, body, body_type, state=state, http_args=http_args
         )
@@ -780,7 +726,6 @@ class Client(oauth2.Client):
 
     def do_check_session_request(
         self,
-        request=None,
         scope="",
         state="",
         body_type="json",
@@ -788,26 +733,10 @@ class Client(oauth2.Client):
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("checksession_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type(
-                "checksession_endpoint"
-            )
+
+        request = self.message_factory.get_request_type("checksession_endpoint")
+        response_cls = self.message_factory.get_response_type("checksession_endpoint")
 
         url, body, ht_args, csi = self.request_info(
             request,
@@ -829,7 +758,6 @@ class Client(oauth2.Client):
 
     def do_check_id_request(
         self,
-        request=None,
         scope="",
         state="",
         body_type="json",
@@ -837,24 +765,9 @@ class Client(oauth2.Client):
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("checkid_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `response_cls` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type("checkid_endpoint")
+        request = self.message_factory.get_request_type("checkid_endpoint")
+        response_cls = self.message_factory.get_response_type("checkid_endpoint")
 
         url, body, ht_args, csi = self.request_info(
             request,
@@ -876,7 +789,6 @@ class Client(oauth2.Client):
 
     def do_end_session_request(
         self,
-        request=None,
         scope="",
         state="",
         body_type="",
@@ -884,24 +796,9 @@ class Client(oauth2.Client):
         request_args=None,
         extra_args=None,
         http_args=None,
-        response_cls=None,
     ):
-        if request is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            request = self.message_factory.get_request_type("endsession_endpoint")
-        if response_cls is not None:
-            warnings.warn(
-                "Passing `request` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            response_cls = self.message_factory.get_response_type("endsession_endpoint")
+        request = self.message_factory.get_request_type("endsession_endpoint")
+        response_cls = self.message_factory.get_response_type("endsession_endpoint")
         url, body, ht_args, _ = self.request_info(
             request,
             method=method,
@@ -1582,10 +1479,6 @@ class Server(oauth2.Server):
 
         return parse_qs(query)
 
-    def parse_token_request(self, request=AccessTokenRequest, body=None):
-        """Overridden to use OIC Message type."""
-        return super().parse_token_request(request=request, body=body)
-
     def handle_request_uri(self, request_uri, verify=True, sender=""):
         """
         Handle request URI.
@@ -1723,10 +1616,6 @@ class Server(oauth2.Server):
         return super().parse_jwt_request(
             request=request, txt=txt, keyjar=keyjar, verify=verify, sender=sender
         )
-
-    def parse_refresh_token_request(self, request=RefreshAccessTokenRequest, body=None):
-        """Overridden to use OIC Message type."""
-        return super().parse_refresh_token_request(request=request, body=body)
 
     def parse_check_session_request(self, url=None, query=None):
         param = self._parse_urlencoded(url, query)

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -787,16 +787,10 @@ class Provider(AProvider):
 
         return req
 
-    def auth_init(self, request, request_class=None):
+    def auth_init(self, request):
         """Overriden since the filter_request can throw an InvalidRequest."""
-        if request_class is not None:
-            warnings.warn(
-                "Passing `request_class` is deprecated. Please use `message_factory` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         try:
-            return super().auth_init(request, request_class)
+            return super().auth_init(request)
         except InvalidRequest as err:
             return error_response("invalid_request", "%s" % err)
 
@@ -1774,45 +1768,13 @@ class Provider(AProvider):
             status_code=403,
         )
 
-    def create_providerinfo(self, pcr_class=None, setup=None):
-        """
-        Overridden to use the proper message class.
-
-        Can be removed once pcr_class is dropped.
-        """
-        if pcr_class is not None:
-            warnings.warn(
-                "Passing `pcr_class` is deprecated. Please use `message_factory.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            pcr_class = self.server.message_factory.get_response_type(
-                "configuration_endpoint"
-            )
-        return super().create_providerinfo(pcr_class=pcr_class, setup=setup)
-
-    def provider_features(self, pcr_class=None, provider_config=None):
+    def provider_features(self, provider_config=None):
         """
         Specify what the server capabilities are.
 
-        :param pcr_class:
         :return: ProviderConfigurationResponse instance
         """
-        if pcr_class is not None:
-            warnings.warn(
-                "Passing `pcr_class` is deprecated. Please use `message_factory.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            pcr_class = self.server.message_factory.get_response_type(
-                "configuration_endpoint"
-            )
-
-        _provider_info = super().provider_features(
-            pcr_class=pcr_class, provider_config=provider_config
-        )
+        _provider_info = super().provider_features(provider_config=provider_config)
 
         # Parse scopes - override the base class
         _scopes = list(SCOPE2CLAIMS.keys())


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---
The failing integration tests have a PR already, so we just need to wait till it gets to upstream and re-run.