### PR TITLE
Properly handle incorrect message decoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ The format is based on the [KeepAChangeLog] project.
 
 ## Unreleased
 
+### Fixed
+- [#602] Fixed uncaught error on unpacking of message
+
 ### Removed
 - [#671] Removed deprecated request/response_cls kwargs from Provider/Client methods
 - [#677] Removed more deprecated code
 
 [#671]: https://github.com/OpenIDC/pyoidc/pull/671
 [#677]: https://github.com/OpenIDC/pyoidc/pull/677
+[#602]: https://github.com/OpenIDC/pyoidc/issues/602
 
 ## 1.0.1 [2019-06-30]
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1567,7 +1567,7 @@ class Provider(AProvider):
         )
         try:
             request = request_cls().deserialize(request, "json")
-        except ValueError:
+        except MessageException:
             request = request_cls().deserialize(request)
 
         logger.info("registration_request:%s" % sanitize(request.to_dict()))

--- a/tests/fakeoicsrv.py
+++ b/tests/fakeoicsrv.py
@@ -8,6 +8,7 @@ from jwkest import jws
 from jwkest.jws import alg2keytype
 
 from oic import rndstr
+from oic.oauth2.message import DecodeError
 from oic.oauth2.message import by_schema
 from oic.oic import Server
 from oic.oic.message import AccessTokenResponse
@@ -215,7 +216,7 @@ class MyFakeOICServer(Server):
     def registration_endpoint(self, data):
         try:
             req = self.parse_registration_request(data, "json")
-        except ValueError:
+        except DecodeError:
             req = self.parse_registration_request(data)
 
         client_secret = rndstr()

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -18,6 +18,7 @@ from oic.oauth2.message import AccessTokenResponse
 from oic.oauth2.message import AuthorizationErrorResponse
 from oic.oauth2.message import AuthorizationRequest
 from oic.oauth2.message import AuthorizationResponse
+from oic.oauth2.message import DecodeError
 from oic.oauth2.message import ErrorResponse
 from oic.oauth2.message import FormatError
 from oic.oauth2.message import GrantExpired
@@ -425,7 +426,7 @@ class TestClient(object):
                 AccessTokenResponse, info=jerr, sformat="urlencoded"
             )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(DecodeError):
             self.client.parse_response(AccessTokenResponse, info=uerr)
 
         with pytest.raises(FormatError):

--- a/tests/test_oauth2_message.py
+++ b/tests/test_oauth2_message.py
@@ -163,12 +163,22 @@ class TestMessage(object):
         assert _eq(item.keys(), ["req_str", "req_str_list", "opt_int"])
         assert item["opt_int"] == 9
 
+    def test_from_json_double_encoded(self):
+        jso = '"{\\"req_str\\": \\"Fair\\"}"'
+        with pytest.raises(DecodeError):
+            DummyMessage().from_json(jso)
+
+    def test_from_json_invalid(self):
+        jso = "{'req_str': 'Fair'}"
+        with pytest.raises(DecodeError):
+            DummyMessage().from_json(jso)
+
     def test_single_optional(self):
         jso = (
             '{"req_str": "Fair", "req_str_list": ["spike", "lee"], '
             '"opt_int": [9, 10]}'
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(MessageException):
             DummyMessage().deserialize(jso, "json")
 
     def test_extra_param(self):

--- a/tests/test_oic_message.py
+++ b/tests/test_oic_message.py
@@ -72,7 +72,7 @@ def test_openidschema():
     ],
 )
 def test_openidschema_from_json(json_param):
-    with pytest.raises(ValueError):
+    with pytest.raises(MessageException):
         OpenIDSchema().from_json(json_param)
 
 
@@ -102,7 +102,7 @@ def test_claim_booleans(json_param):
     ],
 )
 def test_claim_not_booleans(json_param):
-    with pytest.raises(ValueError):
+    with pytest.raises(MessageException):
         OpenIDSchema().from_json(json_param)
 
 


### PR DESCRIPTION
Raise DecodeError on all failures.

Close #602

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [x] The documentation has been updated, if necessary.
- [x] New code is annotated.
- [x] Changes are covered by tests.
---
