### PR TITLE
Logout consumer 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on the [KeepAChangeLog] project.
 
 ## Unreleased
 
+### Changed
+
+- [#688] Second stage of adding logout support.
+
 ### Fixed
 - [#602] Fixed uncaught error on unpacking of message
 - [#679] Make `state` optional in `EndSessionRequest`
@@ -21,6 +25,7 @@ The format is based on the [KeepAChangeLog] project.
 [#602]: https://github.com/OpenIDC/pyoidc/issues/602
 [#679]: https://github.com/OpenIDC/pyoidc/pull/679
 [#683]: https://github.com/OpenIDC/pyoidc/issues/683
+[#688]: https://github.com/OpenIDC/pyoidc/pull/688
 
 ## 1.0.1 [2019-06-30]
 

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -654,7 +654,8 @@ class Client(PBase):
             if "id_token" in resp and self.sso_db:
                 session_update(self.sso_db, _state, "sub", resp["id_token"]["sub"])
                 session_update(self.sso_db, _state, "issuer", resp["id_token"]["iss"])
-
+                if "sid" in resp["id_token"]:
+                    session_update(self.sso_db, _state, "smid", resp["id_token"]["sid"])
         return resp
 
     def init_authentication_method(

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -49,6 +49,7 @@ from oic.utils.http_util import BadRequest
 from oic.utils.http_util import Response
 from oic.utils.http_util import SeeOther
 from oic.utils.keyio import KeyJar
+from oic.utils.session_backend import session_update
 from oic.utils.time_util import utc_time_sans_frac
 
 __author__ = "rohe0002"
@@ -195,6 +196,7 @@ class Client(PBase):
             timeout=timeout,
         )
 
+        self.sso_db = None
         self.client_id = client_id
         self.client_authn_method = client_authn_method
 
@@ -649,8 +651,9 @@ class Client(PBase):
             except KeyError:
                 self.grant[_state] = self.grant_class(resp=resp)
 
-            if 'id_token' in resp:
-                self.sdb.update(_state, "sub", resp["id_token"]["sub"])
+            if "id_token" in resp:
+                session_update(self.sso_db, _state, "sub", resp["id_token"]["sub"])
+                session_update(self.sso_db, _state, "issuer", resp["id_token"]["iss"])
 
         return resp
 

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -651,7 +651,7 @@ class Client(PBase):
             except KeyError:
                 self.grant[_state] = self.grant_class(resp=resp)
 
-            if "id_token" in resp:
+            if "id_token" in resp and self.sso_db:
                 session_update(self.sso_db, _state, "sub", resp["id_token"]["sub"])
                 session_update(self.sso_db, _state, "issuer", resp["id_token"]["iss"])
 

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -49,7 +49,7 @@ from oic.utils.http_util import BadRequest
 from oic.utils.http_util import Response
 from oic.utils.http_util import SeeOther
 from oic.utils.keyio import KeyJar
-from oic.utils.session_backend import session_update
+from oic.utils.sdb import session_update
 from oic.utils.time_util import utc_time_sans_frac
 
 __author__ = "rohe0002"

--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -56,7 +56,7 @@ from oic.utils.http_util import Unauthorized
 from oic.utils.http_util import make_cookie
 from oic.utils.sanitize import sanitize
 from oic.utils.sdb import AccessCodeUsed
-from oic.utils.sdb import AuthnEvent
+from oic.utils.session_backend import AuthnEvent
 
 __author__ = "rohe0002"
 

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -26,9 +26,9 @@ from oic.utils import http_util
 from oic.utils.sanitize import sanitize
 from oic.utils.sdb import DictSessionBackend
 from oic.utils.sdb import SessionBackend
-from oic.utils.session_backend import session_extended_get
-from oic.utils.session_backend import session_get
-from oic.utils.session_backend import session_update
+from oic.utils.sdb import session_extended_get
+from oic.utils.sdb import session_get
+from oic.utils.sdb import session_update
 
 __author__ = "rohe0002"
 

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -548,6 +548,5 @@ class Consumer(Client):
             _sid = session_extended_get(
                 self.sso_db, sub, "issuer", req["logout_token"]["iss"]
             )
-            # _sid = self.sdb.get_by_sub_and_(sub, "issuer", req["logout_token"]["iss"])
 
         return _sid

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -2,8 +2,6 @@ import logging
 import os.path
 import warnings
 
-from jwkest import as_unicode
-
 from oic import rndstr
 from oic.exception import AuthzError
 from oic.exception import MessageException

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -167,7 +167,7 @@ class Consumer(Client):
             )
         self.sdb = session_db
 
-        if sso_db:
+        if sso_db is not None:
             if not isinstance(sso_db, SessionBackend):
                 warnings.warn(
                     "Please use `SessionBackend` to ensure proper API for the database.",

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -541,12 +541,9 @@ class Consumer(Client):
         try:
             sub = req["logout_token"]["sub"]
         except KeyError:
-            try:
-                sm_id = req["logout_token"]["sid"]
-            except KeyError:
-                raise MessageException('Neither "sid" nor "sub"')
-            else:
-                _sid = session_get(self.sso_db, "smid", sm_id)
+            # verify has guaranteed that there will be a sid if sub is missing
+            sm_id = req["logout_token"]["sid"]
+            _sid = session_get(self.sso_db, "smid", sm_id)
         else:
             _sid = session_extended_get(
                 self.sso_db, sub, "issuer", req["logout_token"]["iss"]

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -528,7 +528,7 @@ class Consumer(Client):
         :return: A Session Identifier
         """
         if request:
-            req = BackChannelLogoutRequest().from_urlencoded(as_unicode(request))
+            req = BackChannelLogoutRequest().from_urlencoded(request)
         else:
             req = BackChannelLogoutRequest(**request_args)
 

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -434,7 +434,7 @@ class Consumer(Client):
                 idt = None
             else:
                 try:
-                    session_update(self.sso_db, idt["sid"], "smid", _state)
+                    session_update(self.sso_db, _state, "smid", idt["sid"])
                 except KeyError:
                     pass
 

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -1,6 +1,8 @@
 import logging
 import os.path
 import warnings
+from typing import Dict
+from typing import Optional
 
 from oic import rndstr
 from oic.exception import AuthzError
@@ -516,9 +518,11 @@ class Consumer(Client):
 
     # LOGOUT related
 
-    def backchannel_logout(self, request=None, request_args=None):
+    def backchannel_logout(
+        self, request: Optional[str] = None, request_args: Optional[Dict] = None
+    ) -> str:
         """
-        Receives a back channel logout request and returns a Session ID if the request was OK.
+        Receives a back channel logout request.
 
         :param request: A urlencoded request
         :param request_args: The request as a dictionary
@@ -526,8 +530,10 @@ class Consumer(Client):
         """
         if request:
             req = BackChannelLogoutRequest().from_urlencoded(request)
-        else:
+        elif request_args is not None:
             req = BackChannelLogoutRequest(**request_args)
+        else:
+            raise ValueError("Missing request specification")
 
         kwargs = {"aud": self.client_id, "iss": self.issuer, "keyjar": self.keyjar}
 

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -518,8 +518,7 @@ class Consumer(Client):
 
     def backchannel_logout(self, request=None, request_args=None):
         """
-        Receives a back channel logout request and returns a Session ID
-        if the request was OK.
+        Receives a back channel logout request and returns a Session ID if the request was OK.
 
         :param request: A urlencoded request
         :param request_args: The request as a dictionary

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -568,7 +568,7 @@ class Provider(AProvider):
             "endsession_endpoint"
         )().from_urlencoded(request)
 
-        logger.debug("End session request: {}", sanitize(esr.to_dict()))
+        logger.debug("End session request: {}".format(sanitize(esr.to_dict())))
 
         # 2 ways of find out client ID and user. Either through a cookie
         # or using the id_token_hint

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -2032,7 +2032,8 @@ class Provider(AProvider):
 
     def get_by_sub_and_(self, sub: str, key: str, val: Any) -> Optional[str]:
         """
-        Returns a session ID.
+        Get a session ID based on subject ID and an attribute value pair.
+
         Matches sessions based on a subject identifier (sub) and
         one other claim (key) having value (val).
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -2029,13 +2029,7 @@ class Provider(AProvider):
                 self.keyjar.issuer_keys[""].remove(kb)
 
     def get_uid_by_sub(self, sub):
-        """
-        Should only be one so stop after the first is found.
-        """
-
-        for sid in session_get(self.sdb, "sub", sub):
-            return self.sdb.get_authentication_event(sid).uid
-        return None
+        return self.sdb.get_uid_by_sub(sub)
 
     def get_uid_by_sid(self, sid):
         return self.sdb.get_authentication_event(sid).uid

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -570,7 +570,7 @@ class Provider(AProvider):
             "endsession_endpoint"
         )().from_urlencoded(request)
 
-        logger.debug("End session request: ", format(sanitize(esr.to_dict())))
+        logger.debug("End session request: %s", format(sanitize(esr.to_dict())))
 
         # 2 ways of find out client ID and user. Either through a cookie
         # or using the id_token_hint

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -7,7 +7,6 @@ import time
 from functools import cmp_to_key
 from typing import Dict  # noqa
 from typing import List  # noqa
-from typing import Union  # noqa
 from urllib.parse import parse_qs
 from urllib.parse import splitquery  # type: ignore
 from urllib.parse import unquote
@@ -75,9 +74,9 @@ from oic.utils.keyio import dump_jwks
 from oic.utils.keyio import key_export
 from oic.utils.sanitize import sanitize
 from oic.utils.sdb import AccessCodeUsed
-from oic.utils.sdb import AuthnEvent
 from oic.utils.sdb import ExpiredToken
 from oic.utils.sdb import WrongTokenType
+from oic.utils.session_backend import AuthnEvent
 from oic.utils.template_render import render_template
 from oic.utils.time_util import utc_time_sans_frac
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -42,15 +42,14 @@ from oic.oauth2.exception import VerificationError
 from oic.oauth2.message import Message
 from oic.oauth2.message import by_schema
 from oic.oauth2.provider import DELIM
-from oic.oauth2.provider import STR
 from oic.oauth2.provider import Endpoint
 from oic.oauth2.provider import Provider as AProvider
+from oic.oauth2.provider import STR
 from oic.oic import PREFERENCE2PROVIDER
 from oic.oic import PROVIDER_DEFAULT
 from oic.oic import Server
 from oic.oic import claims_match
 from oic.oic import scope2claims
-from oic.oic.message import SCOPE2CLAIMS
 from oic.oic.message import AccessTokenResponse
 from oic.oic.message import AuthorizationResponse
 from oic.oic.message import Claims
@@ -59,11 +58,12 @@ from oic.oic.message import IdToken
 from oic.oic.message import OIDCMessageFactory
 from oic.oic.message import OpenIDRequest
 from oic.oic.message import OpenIDSchema
+from oic.oic.message import SCOPE2CLAIMS
 from oic.utils import sort_sign_alg
-from oic.utils.http_util import OAUTH2_NOCACHE_HEADERS
 from oic.utils.http_util import BadRequest
 from oic.utils.http_util import CookieDealer
 from oic.utils.http_util import Created
+from oic.utils.http_util import OAUTH2_NOCACHE_HEADERS
 from oic.utils.http_util import Response
 from oic.utils.http_util import SeeOther
 from oic.utils.http_util import Unauthorized
@@ -76,6 +76,7 @@ from oic.utils.sanitize import sanitize
 from oic.utils.sdb import AccessCodeUsed
 from oic.utils.sdb import ExpiredToken
 from oic.utils.sdb import WrongTokenType
+from oic.utils.sdb import session_get
 from oic.utils.session_backend import AuthnEvent
 from oic.utils.template_render import render_template
 from oic.utils.time_util import utc_time_sans_frac
@@ -210,31 +211,31 @@ CAPABILITIES = {
 
 class Provider(AProvider):
     def __init__(
-        self,
-        name,
-        sdb,
-        cdb,
-        authn_broker,
-        userinfo,
-        authz,
-        client_authn,
-        symkey=None,
-        urlmap=None,
-        keyjar=None,
-        hostname="",
-        template_lookup=None,
-        template=None,
-        verify_ssl=True,
-        capabilities=None,
-        schema=OpenIDSchema,
-        jwks_uri="",
-        jwks_name="",
-        baseurl=None,
-        client_cert=None,
-        extra_claims=None,
-        template_renderer=render_template,
-        extra_scope_dict=None,
-        message_factory=OIDCMessageFactory,
+            self,
+            name,
+            sdb,
+            cdb,
+            authn_broker,
+            userinfo,
+            authz,
+            client_authn,
+            symkey=None,
+            urlmap=None,
+            keyjar=None,
+            hostname="",
+            template_lookup=None,
+            template=None,
+            verify_ssl=True,
+            capabilities=None,
+            schema=OpenIDSchema,
+            jwks_uri="",
+            jwks_name="",
+            baseurl=None,
+            client_cert=None,
+            extra_claims=None,
+            template_renderer=render_template,
+            extra_scope_dict=None,
+            message_factory=OIDCMessageFactory,
     ):
 
         # This has to be defined before calling super()
@@ -353,17 +354,17 @@ class Provider(AProvider):
                     self.capabilities[val] = [_enc_enc]
 
     def id_token_as_signed_jwt(
-        self,
-        session,
-        loa="2",
-        alg="",
-        code=None,
-        access_token=None,
-        user_info=None,
-        auth_time=0,
-        exp=None,
-        extra_claims=None,
-        **kwargs
+            self,
+            session,
+            loa="2",
+            alg="",
+            code=None,
+            access_token=None,
+            user_info=None,
+            auth_time=0,
+            exp=None,
+            extra_claims=None,
+            **kwargs
     ):
 
         if alg == "":
@@ -557,7 +558,7 @@ class Provider(AProvider):
             if typ == "sso":
                 uid, client_id = value.split(DELIM)
                 try:
-                    sids = self.sdb.get_by_uid(uid)
+                    sids = session_get(self.sdb, "uid", uid)
                 except (KeyError, IndexError):
                     raise SubMismatch("Mismatch uid")
         return cookie_dealer, client_id, sids
@@ -764,7 +765,7 @@ class Provider(AProvider):
 
         if "response_type" in req:
             if not self.match_sp_sep(
-                [" ".join(req["response_type"])], _cap["response_types_supported"]
+                    [" ".join(req["response_type"])], _cap["response_types_supported"]
             ):
                 raise InvalidRequest("Contains unsupported response type")
 
@@ -933,7 +934,7 @@ class Provider(AProvider):
         return _jwe.encrypt(keys, context="public")
 
     def sign_encrypt_id_token(
-        self, sinfo, client_info, areq, code=None, access_token=None, user_info=None
+            self, sinfo, client_info, areq, code=None, access_token=None, user_info=None
     ):
         """
         Sign and or encrypt a IDToken.
@@ -1223,7 +1224,7 @@ class Provider(AProvider):
             _token = kwargs.get("authn", "") or ""
             if not _token.startswith("Bearer "):
                 raise ParameterError("Token is missing or malformed")
-            _token = _token[len("Bearer ") :]
+            _token = _token[len("Bearer "):]
             logger.debug("Bearer token {} chars".format(len(_token)))
         else:
             args = {"data": request}
@@ -1341,7 +1342,7 @@ class Provider(AProvider):
                             raise CapabilitiesMisMatch(_pref)
                     else:
                         if not set(request[_pref]).issubset(
-                            set(self.capabilities[_prov])
+                                set(self.capabilities[_prov])
                         ):
                             raise CapabilitiesMisMatch(_pref)
 
@@ -1363,8 +1364,8 @@ class Provider(AProvider):
                     err = ClientRegistrationErrorResponse(
                         error="invalid_configuration_parameter",
                         error_description="post_logout_redirect_uris "
-                        "contains "
-                        "fragment",
+                                          "contains "
+                                          "fragment",
                     )
                     return Response(
                         err.to_json(),
@@ -1693,7 +1694,7 @@ class Provider(AProvider):
         # database.
         if not authn.startswith("Bearer "):
             return error_response("invalid_request")
-        token = authn[len("Bearer ") :]
+        token = authn[len("Bearer "):]
 
         # Get client_id from request
         _info = parse_qs(request)
@@ -2026,3 +2027,23 @@ class Provider(AProvider):
                         kb.remove(key)
             if len(kb) == 0:
                 self.keyjar.issuer_keys[""].remove(kb)
+
+    def get_uid_by_sub(self, sub):
+        """
+        Should only be one so stop after the first is found.
+        """
+        for sid in self.sdb.get_by_sub(sub):
+            return AuthnEvent.from_json(self.sdb[sid]["authn_event"]).uid
+        return None
+
+    def get_uid_by_sid(self, sid):
+        return AuthnEvent.from_json(self.sdb[sid]["authn_event"]).uid
+
+    def get_by_sub_and_(self, sub, key, val):
+        for sid in self.sdb.get_by_sub(sub):
+            try:
+                if self.sdb[sid][key] == val:
+                    return sid
+            except KeyError:
+                continue
+        return None

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -42,14 +42,15 @@ from oic.oauth2.exception import VerificationError
 from oic.oauth2.message import Message
 from oic.oauth2.message import by_schema
 from oic.oauth2.provider import DELIM
+from oic.oauth2.provider import STR
 from oic.oauth2.provider import Endpoint
 from oic.oauth2.provider import Provider as AProvider
-from oic.oauth2.provider import STR
 from oic.oic import PREFERENCE2PROVIDER
 from oic.oic import PROVIDER_DEFAULT
 from oic.oic import Server
 from oic.oic import claims_match
 from oic.oic import scope2claims
+from oic.oic.message import SCOPE2CLAIMS
 from oic.oic.message import AccessTokenResponse
 from oic.oic.message import AuthorizationResponse
 from oic.oic.message import Claims
@@ -58,12 +59,11 @@ from oic.oic.message import IdToken
 from oic.oic.message import OIDCMessageFactory
 from oic.oic.message import OpenIDRequest
 from oic.oic.message import OpenIDSchema
-from oic.oic.message import SCOPE2CLAIMS
 from oic.utils import sort_sign_alg
+from oic.utils.http_util import OAUTH2_NOCACHE_HEADERS
 from oic.utils.http_util import BadRequest
 from oic.utils.http_util import CookieDealer
 from oic.utils.http_util import Created
-from oic.utils.http_util import OAUTH2_NOCACHE_HEADERS
 from oic.utils.http_util import Response
 from oic.utils.http_util import SeeOther
 from oic.utils.http_util import Unauthorized
@@ -211,31 +211,31 @@ CAPABILITIES = {
 
 class Provider(AProvider):
     def __init__(
-            self,
-            name,
-            sdb,
-            cdb,
-            authn_broker,
-            userinfo,
-            authz,
-            client_authn,
-            symkey=None,
-            urlmap=None,
-            keyjar=None,
-            hostname="",
-            template_lookup=None,
-            template=None,
-            verify_ssl=True,
-            capabilities=None,
-            schema=OpenIDSchema,
-            jwks_uri="",
-            jwks_name="",
-            baseurl=None,
-            client_cert=None,
-            extra_claims=None,
-            template_renderer=render_template,
-            extra_scope_dict=None,
-            message_factory=OIDCMessageFactory,
+        self,
+        name,
+        sdb,
+        cdb,
+        authn_broker,
+        userinfo,
+        authz,
+        client_authn,
+        symkey=None,
+        urlmap=None,
+        keyjar=None,
+        hostname="",
+        template_lookup=None,
+        template=None,
+        verify_ssl=True,
+        capabilities=None,
+        schema=OpenIDSchema,
+        jwks_uri="",
+        jwks_name="",
+        baseurl=None,
+        client_cert=None,
+        extra_claims=None,
+        template_renderer=render_template,
+        extra_scope_dict=None,
+        message_factory=OIDCMessageFactory,
     ):
 
         # This has to be defined before calling super()
@@ -354,17 +354,17 @@ class Provider(AProvider):
                     self.capabilities[val] = [_enc_enc]
 
     def id_token_as_signed_jwt(
-            self,
-            session,
-            loa="2",
-            alg="",
-            code=None,
-            access_token=None,
-            user_info=None,
-            auth_time=0,
-            exp=None,
-            extra_claims=None,
-            **kwargs
+        self,
+        session,
+        loa="2",
+        alg="",
+        code=None,
+        access_token=None,
+        user_info=None,
+        auth_time=0,
+        exp=None,
+        extra_claims=None,
+        **kwargs
     ):
 
         if alg == "":
@@ -765,7 +765,7 @@ class Provider(AProvider):
 
         if "response_type" in req:
             if not self.match_sp_sep(
-                    [" ".join(req["response_type"])], _cap["response_types_supported"]
+                [" ".join(req["response_type"])], _cap["response_types_supported"]
             ):
                 raise InvalidRequest("Contains unsupported response type")
 
@@ -934,7 +934,7 @@ class Provider(AProvider):
         return _jwe.encrypt(keys, context="public")
 
     def sign_encrypt_id_token(
-            self, sinfo, client_info, areq, code=None, access_token=None, user_info=None
+        self, sinfo, client_info, areq, code=None, access_token=None, user_info=None
     ):
         """
         Sign and or encrypt a IDToken.
@@ -1224,7 +1224,7 @@ class Provider(AProvider):
             _token = kwargs.get("authn", "") or ""
             if not _token.startswith("Bearer "):
                 raise ParameterError("Token is missing or malformed")
-            _token = _token[len("Bearer "):]
+            _token = _token[len("Bearer ") :]
             logger.debug("Bearer token {} chars".format(len(_token)))
         else:
             args = {"data": request}
@@ -1342,7 +1342,7 @@ class Provider(AProvider):
                             raise CapabilitiesMisMatch(_pref)
                     else:
                         if not set(request[_pref]).issubset(
-                                set(self.capabilities[_prov])
+                            set(self.capabilities[_prov])
                         ):
                             raise CapabilitiesMisMatch(_pref)
 
@@ -1364,8 +1364,8 @@ class Provider(AProvider):
                     err = ClientRegistrationErrorResponse(
                         error="invalid_configuration_parameter",
                         error_description="post_logout_redirect_uris "
-                                          "contains "
-                                          "fragment",
+                        "contains "
+                        "fragment",
                     )
                     return Response(
                         err.to_json(),
@@ -1694,7 +1694,7 @@ class Provider(AProvider):
         # database.
         if not authn.startswith("Bearer "):
             return error_response("invalid_request")
-        token = authn[len("Bearer "):]
+        token = authn[len("Bearer ") :]
 
         # Get client_id from request
         _info = parse_qs(request)

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -2032,12 +2032,13 @@ class Provider(AProvider):
         """
         Should only be one so stop after the first is found.
         """
-        for sid in self.sdb.get_by_sub(sub):
-            return AuthnEvent.from_json(self.sdb[sid]["authn_event"]).uid
+
+        for sid in session_get(self.sdb, "sub", sub):
+            return self.sdb.get_authentication_event(sid).uid
         return None
 
     def get_uid_by_sid(self, sid):
-        return AuthnEvent.from_json(self.sdb[sid]["authn_event"]).uid
+        return self.sdb.get_authentication_event(sid).uid
 
     def get_by_sub_and_(self, sub, key, val):
         for sid in self.sdb.get_by_sub(sub):

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -570,7 +570,7 @@ class Provider(AProvider):
             "endsession_endpoint"
         )().from_urlencoded(request)
 
-        logger.debug("End session request: {}".format(sanitize(esr.to_dict())))
+        logger.debug("End session request: ", format(sanitize(esr.to_dict())))
 
         # 2 ways of find out client ID and user. Either through a cookie
         # or using the id_token_hint

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -5,8 +5,10 @@ import logging
 import socket
 import time
 from functools import cmp_to_key
+from typing import Any
 from typing import Dict  # noqa
 from typing import List  # noqa
+from typing import Optional
 from urllib.parse import parse_qs
 from urllib.parse import splitquery  # type: ignore
 from urllib.parse import unquote
@@ -2028,7 +2030,17 @@ class Provider(AProvider):
             if len(kb) == 0:
                 self.keyjar.issuer_keys[""].remove(kb)
 
-    def get_by_sub_and_(self, sub, key, val):
+    def get_by_sub_and_(self, sub: str, key: str, val: Any) -> Optional[str]:
+        """
+        Returns a session ID.
+        Matches sessions based on a subject identifier (sub) and
+        one other claim (key) having value (val).
+
+        :param sub: The subject identifier
+        :param key: A claim in the session information
+        :param val: A value
+        :return: A session ID
+        """
         for sid in self.sdb.get_by_sub(sub):
             try:
                 if self.sdb[sid][key] == val:

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -2028,12 +2028,6 @@ class Provider(AProvider):
             if len(kb) == 0:
                 self.keyjar.issuer_keys[""].remove(kb)
 
-    def get_uid_by_sub(self, sub):
-        return self.sdb.get_uid_by_sub(sub)
-
-    def get_uid_by_sid(self, sid):
-        return self.sdb.get_authentication_event(sid).uid
-
     def get_by_sub_and_(self, sub, key, val):
         for sid in self.sdb.get_by_sub(sub):
             try:

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -38,7 +38,7 @@ def lv_unpack(txt):
     while txt:
         l, v = txt.split(":", 1)
         res.append(v[: int(l)])
-        txt = v[int(l):]
+        txt = v[int(l) :]
     return res
 
 
@@ -352,7 +352,7 @@ class DictRefreshDB(RefreshDB):
         warnings.warn(
             "Using `DictRefreshDB` is deprecated, please use `Token` and `refresh_token_factory` instead.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         self._db = {}  # type: Dict[str, Dict[str, str]]
 
@@ -370,13 +370,13 @@ class DictRefreshDB(RefreshDB):
 
 
 def create_session_db(
-        base_url,
-        secret,
-        password,
-        db=None,
-        token_expires_in=3600,
-        grant_expires_in=600,
-        refresh_token_expires_in=86400,
+    base_url,
+    secret,
+    password,
+    db=None,
+    token_expires_in=3600,
+    grant_expires_in=600,
+    refresh_token_expires_in=86400,
 ):
     """
     Construct SessionDB instance.
@@ -413,15 +413,15 @@ def create_session_db(
 
 class SessionDB(object):
     def __init__(
-            self,
-            base_url,
-            db,
-            refresh_db=None,
-            refresh_token_expires_in=None,
-            token_factory=None,
-            code_factory=None,
-            refresh_token_factory=None,
-            sm_salt=''
+        self,
+        base_url,
+        db,
+        refresh_db=None,
+        refresh_token_expires_in=None,
+        token_factory=None,
+        code_factory=None,
+        refresh_token_factory=None,
+        sm_salt="",
     ):
         """
         Object to store the session related information.
@@ -649,13 +649,13 @@ class SessionDB(object):
             return self._db[sid]["access_token"]
 
     def upgrade_to_token(
-            self,
-            token=None,
-            issue_refresh=False,
-            id_token="",
-            oidreq=None,
-            key=None,
-            access_grant="",
+        self,
+        token=None,
+        issue_refresh=False,
+        id_token="",
+        oidreq=None,
+        key=None,
+        access_grant="",
     ):
         """
         Promote session to token.
@@ -883,8 +883,7 @@ class SessionDB(object):
 
     def get_client_ids_for_uid(self, uid: str) -> List[str]:
         """Return client_ids for a given uid."""
-        return [self.get_client_id_for_session(sid) for sid in
-                self._db.get_by_uid(uid)]
+        return [self.get_client_id_for_session(sid) for sid in self._db.get_by_uid(uid)]
 
     def get_verify_logout(self, uid: str) -> Dict:
         """Return the dictionary for logout verification."""
@@ -908,7 +907,7 @@ class SessionDB(object):
         for sid in self._db.get_by_uid(uid):
             _dict = self._db[sid]
             try:
-                res[_dict['client_id']] = _dict['id_token']
+                res[_dict["client_id"]] = _dict["id_token"]
             except KeyError:
                 pass
         return res
@@ -988,4 +987,6 @@ class SessionDB(object):
         :return: A session management ID
         """
 
-        return hashlib.sha256("{}{}".format(sid, self.sm_salt).encode("utf-8")).hexdigest()
+        return hashlib.sha256(
+            "{}{}".format(sid, self.sm_salt).encode("utf-8")
+        ).hexdigest()

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -970,12 +970,11 @@ class SessionDB(object):
 
     def make_smid(self, sid):
         """
-        Create a session management ID
+        Create a session management ID.
 
         :param sid:
         :return: A session management ID
         """
-
         return hashlib.sha256(
             "{}{}".format(sid, self.sm_salt).encode("utf-8")
         ).hexdigest()
@@ -994,7 +993,7 @@ class SessionDB(object):
 
 
 def session_get(db, attr, val):
-    """Return session ID based on attribute having value val"""
+    """Return session ID based on attribute having value val."""
     if isinstance(db, (SessionBackend, SessionDB)):
         if attr == "uid":
             return db.get_by_uid(val)
@@ -1021,7 +1020,7 @@ def session_get(db, attr, val):
 
 
 def session_extended_get(db, sub, attr, val):
-    """Return session ID based on subject_id and attribute attr having value val"""
+    """Return session ID based on subject_id and attribute attr having value val."""
     if isinstance(db, (SessionBackend, SessionDB)):
         for sid in db.get_by_sub(sub):
             try:

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -989,6 +989,9 @@ class SessionDB(object):
     def get_uid_by_sub(self, sub):
         return self._db.get_uid_by_sub(sub)
 
+    def get_uid_by_sid(self, sub):
+        return self._db.get_uid_by_sid(sub)
+
 
 def session_get(db, attr, val):
     """Return session ID based on attribute having value val"""

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -981,7 +981,7 @@ class SessionDB(object):
         ).hexdigest()
 
     def get(self, attr, val):
-        self._db.get(attr, val)
+        return self._db.get(attr, val)
 
     def get_by_uid(self, uid: str) -> List[str]:
         return self._db.get_by_uid(uid)

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -14,6 +14,7 @@ from cryptography.fernet import InvalidToken
 
 from oic import rndstr
 from oic.exception import ImproperlyConfigured
+from oic.oic import AuthorizationRequest
 from oic.utils import tobytes
 from oic.utils.session_backend import AuthnEvent
 from oic.utils.session_backend import DictSessionBackend
@@ -952,7 +953,7 @@ class SessionDB(object):
                 pass
 
         self._db[sid] = _dic
-        self._db.update_sub2sid_map(_dic["sub"], sid)
+        self._db.update(sid, "sub", _dic["sub"])
 
         return sid
 

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -885,7 +885,7 @@ class SessionDB(object):
 
     def get_client_ids_for_uid(self, uid: str) -> List[str]:
         """Return client_ids for a given uid."""
-        return [self.get_client_id_for_session(sid) for sid in self._db.get_by_uid(uid)]
+        return self._db.get_client_ids_for_uid(uid)
 
     def get_verify_logout(self, uid: str) -> Optional[str]:
         """Return logout verification key for given uid."""

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 import warnings
 from binascii import Error
+from typing import Any
 from typing import Dict  # noqa
 from typing import List  # noqa
 from typing import Optional
@@ -961,7 +962,7 @@ class SessionDB(object):
         """Return session ids based on `sub` (external user identifier)."""
         return self._db.get_by_sub(sub)
 
-    def make_smid(self, sid):
+    def make_smid(self, sid: str) -> str:
         """
         Create a session management ID.
 
@@ -972,16 +973,20 @@ class SessionDB(object):
             "{}{}".format(sid, self.sm_salt).encode("utf-8")
         ).hexdigest()
 
-    def get(self, attr, val):
+    def get(self, attr: str, val: Any) -> List[str]:
+        """Return session ids based on attribute name and value."""
         return self._db.get(attr, val)
 
     def get_by_uid(self, uid: str) -> List[str]:
+        """Return session ids (keys) based on `uid` (internal user identifier)."""
         return self._db.get_by_uid(uid)
 
     def get_uid_by_sub(self, sub: str) -> str:
+        """Return session ids based on `sub` (external user identifier)."""
         return self._db.get_uid_by_sub(sub)
 
     def get_uid_by_sid(self, sub: str) -> str:
+        """Return User id based on sub."""
         return self._db.get_uid_by_sid(sub)
 
 

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -890,6 +890,10 @@ class SessionDB(object):
         """Return the dictionary for logout verification."""
         return self._db.get_verified_logout(uid)
 
+    def get_token_ids(self, uid: str) -> List[str]:
+        """Return id_tokens for given uid."""
+        return self._db.get_token_ids(uid)
+
     def set_verify_logout(self, uid: str) -> None:
         """Save the key that is used for logout verification."""
         for sid in self._db.get_by_uid(uid):
@@ -906,14 +910,9 @@ class SessionDB(object):
                 pass
         return res
 
-    def is_revoke_uid(self, uid: str) -> Dict:
-        res = {}
-        for sid in self._db.get_by_uid(uid):
-            try:
-                res[sid] = self._db[sid]["revoked"]
-            except KeyError:
-                res[sid] = None
-        return res
+    def is_revoke_uid(self, uid: str) -> bool:
+        """Return if the uid session has been revoked."""
+        return self._db.is_revoke_uid(uid)
 
     def revoke_uid(self, uid: str) -> None:
         """Mark all sessions for the given uid as revoked."""
@@ -959,6 +958,7 @@ class SessionDB(object):
         return self._db[key]
 
     def get_by_sub(self, sub: str) -> List[str]:
+        """Return session ids based on `sub` (external user identifier)."""
         return self._db.get_by_sub(sub)
 
     def make_smid(self, sid):

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -995,6 +995,12 @@ def session_get(db, attr, val):
         else:
             return db.get(attr, val)
     elif isinstance(db, dict):
+        warnings.warn(
+            "Using a regular dictionary is deprecated, please use `SessionDB` or `SessionBackend` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if attr == "uid":
             for _key, _val in db.items():
                 if _val['authn_event']["uid"] == val:
@@ -1019,6 +1025,11 @@ def session_extended_get(db, sub, attr, val):
                 continue
         return None
     elif isinstance(db, dict):
+        warnings.warn(
+            "Using a regular dictionary is deprecated, please use `SessionDB` or `SessionBackend` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         for _key, _val in db.items():
             try:
                 if _val["sub"] == sub and _val[attr] == val:
@@ -1036,6 +1047,11 @@ def session_set(db, attr, val):
     elif isinstance(db, SessionDB):
         db._db.set(attr, val)
     elif isinstance(db, dict):
+        warnings.warn(
+            "Using a regular dictionary is deprecated, please use `SessionDB` or `SessionBackend` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db[attr] = val
     else:
         raise ValueError("Unknown session database type")
@@ -1047,6 +1063,11 @@ def session_update(db, key, attr, val):
     elif isinstance(db, SessionDB):
         db._db.update(key, attr, val)
     elif isinstance(db, dict):
+        warnings.warn(
+            "Using a regular dictionary is deprecated, please use `SessionDB` or `SessionBackend` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         item = db[key]
         item[attr] = val
         db[key] = item

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -986,6 +986,9 @@ class SessionDB(object):
     def get_by_uid(self, uid: str) -> List[str]:
         return self._db.get_by_uid(uid)
 
+    def get_uid_by_sub(self, sub):
+        return self._db.get_uid_by_sub(sub)
+
 
 def session_get(db, attr, val):
     """Return session ID based on attribute having value val"""

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -901,16 +901,6 @@ class SessionDB(object):
             _dict = self._db[sid]
             _dict["verified_logout"] = uuid.uuid4().urn
 
-    def get_id_token(self, uid: str) -> Dict:
-        res = {}
-        for sid in self._db.get_by_uid(uid):
-            _dict = self._db[sid]
-            try:
-                res[_dict["client_id"]] = _dict["id_token"]
-            except KeyError:
-                pass
-        return res
-
     def is_revoke_uid(self, uid: str) -> bool:
         """Return if the uid session has been revoked."""
         return self._db.is_revoke_uid(uid)

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -888,7 +888,7 @@ class SessionDB(object):
         return [self.get_client_id_for_session(sid) for sid in self._db.get_by_uid(uid)]
 
     def get_verify_logout(self, uid: str) -> Optional[str]:
-        """Return the dictionary for logout verification."""
+        """Return logout verification key for given uid."""
         return self._db.get_verified_logout(uid)
 
     def get_token_ids(self, uid: str) -> List[str]:

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -11,10 +11,10 @@ from typing import List  # noqa
 
 from cryptography.fernet import Fernet
 from cryptography.fernet import InvalidToken
-from oic.oauth2.message import AuthorizationRequest
 
 from oic import rndstr
 from oic.exception import ImproperlyConfigured
+from oic.oauth2.message import AuthorizationRequest
 from oic.utils import tobytes
 from oic.utils.session_backend import AuthnEvent
 from oic.utils.session_backend import DictSessionBackend
@@ -1003,7 +1003,7 @@ def session_get(db, attr, val):
 
         if attr == "uid":
             for _key, _val in db.items():
-                if _val['authn_event']["uid"] == val:
+                if _val["authn_event"]["uid"] == val:
                     return _key
         else:
             for _key, _val in db.items():

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -442,8 +442,9 @@ class SessionDB(object):
                 DeprecationWarning,
             )
         self._db = db
-        if sm_salt:
-            self._db.set_sm_salt(sm_salt)
+
+        self.sm_salt = sm_salt or rndstr(32)
+        self._db.set_sm_salt(sm_salt)
 
         self.token_factory = {"code": code_factory, "access_token": token_factory}
 
@@ -474,7 +475,6 @@ class SessionDB(object):
 
         self.access_token = self.token_factory["access_token"]
         self.token = self.access_token
-        self.sm_salt = sm_salt or rndstr(32)
 
     def _get_token_key(self, item, order=None):
         if order is None:
@@ -965,7 +965,7 @@ class SessionDB(object):
 
         return self._db[key]
 
-    def get_by_sub(self, sub):
+    def get_by_sub(self, sub: str) -> List[str]:
         return self._db.get_by_sub(sub)
 
     def make_smid(self, sid):
@@ -985,10 +985,10 @@ class SessionDB(object):
     def get_by_uid(self, uid: str) -> List[str]:
         return self._db.get_by_uid(uid)
 
-    def get_uid_by_sub(self, sub):
+    def get_uid_by_sub(self, sub: str) -> str:
         return self._db.get_uid_by_sub(sub)
 
-    def get_uid_by_sid(self, sub):
+    def get_uid_by_sid(self, sub: str) -> str:
         return self._db.get_uid_by_sid(sub)
 
 

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -444,7 +444,6 @@ class SessionDB(object):
         self._db = db
 
         self.sm_salt = sm_salt or rndstr(32)
-        self._db.set_sm_salt(sm_salt)
 
         self.token_factory = {"code": code_factory, "access_token": token_factory}
 

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -8,6 +8,7 @@ import warnings
 from binascii import Error
 from typing import Dict  # noqa
 from typing import List  # noqa
+from typing import Optional
 
 from cryptography.fernet import Fernet
 from cryptography.fernet import InvalidToken
@@ -885,16 +886,9 @@ class SessionDB(object):
         """Return client_ids for a given uid."""
         return [self.get_client_id_for_session(sid) for sid in self._db.get_by_uid(uid)]
 
-    def get_verify_logout(self, uid: str) -> Dict:
+    def get_verify_logout(self, uid: str) -> Optional[str]:
         """Return the dictionary for logout verification."""
-        res = {}
-        for sid in self._db.get_by_uid(uid):
-            _dict = self._db[sid]
-            try:
-                res[sid] = _dict["verified_logout"]
-            except KeyError:
-                res[sid] = None
-        return res
+        return self._db.get_verified_logout(uid)
 
     def set_verify_logout(self, uid: str) -> None:
         """Save the key that is used for logout verification."""

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -183,7 +183,7 @@ class DictSessionBackend(SessionBackend):
 
     def get_uid_by_sub(self, sub):
         """Return User ids based on sub. Should only be one."""
-        for sid, session in self.storage.items():
+        for session in self.storage.values():
             if session.get("sub") == sub:
                 return AuthnEvent.from_json(session["authn_event"]).uid
         return None

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -2,8 +2,10 @@ import json
 import time
 from abc import ABCMeta
 from abc import abstractmethod
+from typing import Any
 from typing import Dict
 from typing import List
+from typing import NoReturn
 from typing import Optional
 
 from oic.utils.time_util import time_sans_frac
@@ -111,7 +113,7 @@ class SessionBackend(metaclass=ABCMeta):
         # We do not care which session it is - once revoked, al are revoked
         return any([self[sid]["revoked"] for sid in self.get_by_uid(uid)])
 
-    def update(self, key, attribute, value):
+    def update(self, key: str, attribute: str, value: Any) -> NoReturn:
         """
         Updates information stored. If the key is not know a new entry will be
         constructed.

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -127,7 +127,7 @@ class SessionBackend(metaclass=ABCMeta):
             item[attribute] = value
             self[key] = item
 
-    def get_uid_by_sub(self, sub):
+    def get_uid_by_sub(self, sub: str) -> str:
         """Return User ids based on sub. Should only be one."""
         uid = ""
         for sid in self.get_by_sub(sub):
@@ -138,8 +138,8 @@ class SessionBackend(metaclass=ABCMeta):
                 uid = AuthnEvent.from_json(self[sid]["authn_event"]).uid
         return uid
 
-    def get_uid_by_sid(self, sid):
-        """Return session ids based on uid."""
+    def get_uid_by_sid(self, sid: str) -> str:
+        """Return User id based on session ID."""
         return AuthnEvent.from_json(self[sid]["authn_event"]).uid
 
 

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -111,7 +111,6 @@ class SessionBackend(metaclass=ABCMeta):
         # We do not care which session it is - once revoked, al are revoked
         return any([self[sid]["revoked"] for sid in self.get_by_uid(uid)])
 
-
     def update(self, key, attribute, value):
         """
         Updates information stored. If the key is not know a new entry will be
@@ -200,5 +199,3 @@ class DictSessionBackend(SessionBackend):
             item = self.storage[key]
             item[attribute] = value
             self.storage[key] = item
-
-

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -127,6 +127,13 @@ class SessionBackend(metaclass=ABCMeta):
             item[attribute] = value
             self[key] = item
 
+    def get_uid_by_sub(self, sub):
+        """Return User ids based on sub. Should only be one."""
+
+    def get_uid_by_sid(self, sid):
+        """Return session ids based on uid"""
+        return self.get_uid_by_sub(self[sid]["sub"])
+
 
 class DictSessionBackend(SessionBackend):
     """

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -114,7 +114,7 @@ class SessionBackend(metaclass=ABCMeta):
 
     def update(self, key: str, attribute: str, value: Any):
         """
-        Updates information stored. If the key is not know a new entry will be constructed.
+        Update information stored. If the key is not know a new entry will be constructed.
 
         :param key: Key to the database
         :param attribute: Attribute name

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -132,7 +132,7 @@ class SessionBackend(metaclass=ABCMeta):
 
     def get_uid_by_sid(self, sid):
         """Return session ids based on uid"""
-        return self.get_uid_by_sub(self[sid]["sub"])
+        return AuthnEvent.from_json(self[sid]["authn_event"]).uid
 
 
 class DictSessionBackend(SessionBackend):
@@ -189,7 +189,7 @@ class DictSessionBackend(SessionBackend):
         return None
 
     def get_uid_by_sid(self, sid):
-        return self.get_uid_by_sub(self.storage[sid]["sub"])
+        return AuthnEvent.from_json(self.storage[sid]["authn_event"]).uid
 
     def update(self, key, attribute, value):
         """

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -1,0 +1,293 @@
+import json
+import time
+from abc import ABCMeta
+from abc import abstractmethod
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from oic.utils.time_util import time_sans_frac
+
+
+class AuthnEvent(object):
+    def __init__(
+            self,
+            uid,
+            salt,
+            valid=3600,
+            authn_info=None,
+            time_stamp=0,
+            authn_time=None,
+            valid_until=None,
+    ):
+        """
+        Create a representation of an authentication event.
+
+        :param uid: The local user identifier
+        :param salt: Salt to be used in creating a sub
+        :param valid: How long the authentication is expected to be valid
+        :param authn_info: Info about the authentication event
+        :return:
+        """
+        self.uid = uid
+        self.salt = salt
+        self.authn_time = authn_time or (int(time_stamp) or time_sans_frac())
+        self.valid_until = valid_until or (self.authn_time + int(valid))
+        self.authn_info = authn_info
+
+    def valid(self):
+        return self.valid_until > time.time()
+
+    def valid_for(self):
+        return self.valid_until - time.time()
+
+    def to_json(self):
+        """Serialize AuthnEvent to JSON."""
+        return json.dumps(self.__dict__)
+
+    @classmethod
+    def from_json(cls, json_struct):
+        """Create AuthnEvent from JSON."""
+        dic = json.loads(json_struct)
+        return cls(**dic)
+
+
+class SessionBackend(metaclass=ABCMeta):
+    """Backend for storing sessionDB data."""
+
+    @abstractmethod
+    def __setitem__(self, key: str, value: Dict[str, str]) -> None:
+        """Store the session information under the session_id."""
+
+    @abstractmethod
+    def __getitem__(self, key: str) -> Dict[str, str]:
+        """
+        Retrieve the session information based os session_id.
+
+        @raises KeyError when no key is found.
+        """
+
+    @abstractmethod
+    def __delitem__(self, key: str) -> None:
+        """Remove the stored session from storage."""
+
+    @abstractmethod
+    def __contains__(self, key: str) -> bool:
+        """Test presence of key in storage."""
+
+    @abstractmethod
+    def get_by_uid(self, uid: str) -> List[str]:
+        """Return session ids (keys) based on `uid` (internal user identifier)."""
+
+    @abstractmethod
+    def get_by_sub(self, sub: str) -> List[str]:
+        """Return session ids based on `sub` (external user identifier)."""
+
+    @abstractmethod
+    def get(self, attr: str, val: str) -> List[str]:
+        """Return session ids based on attribute name and value."""
+
+    def get_client_ids_for_uid(self, uid: str) -> List[str]:
+        """Return client ids that have a session for given uid."""
+        return [self[sid]["client_id"] for sid in self.get_by_uid(uid)]
+
+    def get_verified_logout(self, uid: str) -> Optional[str]:
+        """Return logout verification key for given uid."""
+        # Since all the sessions should be the same, we return the first one
+        sids = self.get_by_uid(uid)
+        if len(sids) == 0:
+            return None
+        _dict = self[sids[0]]
+        if "verified_logout" not in _dict:
+            return None
+        return _dict["verified_logout"]
+
+    def get_token_ids(self, uid: str) -> List[str]:
+        """Return id_tokens for the given uid."""
+        return [self[sid]["id_token"] for sid in self.get_by_uid(uid)]
+
+    def is_revoke_uid(self, uid: str) -> bool:
+        """Return if the session is revoked."""
+        # We do not care which session it is - once revoked, al are revoked
+        return any([self[sid]["revoked"] for sid in self.get_by_uid(uid)])
+
+    def get_uid_by_sub(self, sub):
+        """
+        Should only be one so stop after the first is found.
+        """
+        for sid in self.get_by_sub(sub):
+            return AuthnEvent.from_json(self[sid]["authn_event"]).uid
+        return None
+
+    def get_uid_by_sid(self, sid):
+        return AuthnEvent.from_json(self[sid]["authn_event"]).uid
+
+    def get_by_sub_and_(self, sub, key, val):
+        for sid in self.get_by_sub(sub):
+            try:
+                if self[sid][key] == val:
+                    return sid
+            except KeyError:
+                continue
+        return None
+
+    def update(self, key, attribute, value):
+        """
+        Updates information stored. If the key is not know a new entry will be
+        constructed.
+
+        :param key: Key to the database
+        :param attribute: Attribute name
+        :param value: Attribute value
+        """
+        if key not in self:
+            self[key] = {attribute: value}
+        else:
+            item = self[key]
+            item[attribute] = value
+            self[key] = item
+
+
+class DictSessionBackend(SessionBackend):
+    """
+    Simple implementation of `SessionBackend` based on dictionary.
+
+    This should really not be used in production.
+    """
+
+    def __init__(self):
+        """Create the storage."""
+        self.storage = {}  # type: Dict[str, Dict[str, str]]
+
+    def __setitem__(self, key: str, value: Dict[str, str]) -> None:
+        """Store the session info in the storage."""
+        self.storage[key] = value
+
+    def __getitem__(self, key: str) -> Dict[str, str]:
+        """Retrieve session information based on session id."""
+        return self.storage[key]
+
+    def __delitem__(self, key: str) -> None:
+        """Delete the session info."""
+        del self.storage[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.storage
+
+    def get_by_sub(self, sub: str) -> List[str]:
+        """Return session ids based on sub."""
+        return [
+            sid for sid, session in self.storage.items() if session.get("sub") == sub
+        ]
+
+    def get_by_uid(self, uid: str) -> List[str]:
+        """Return session ids based on uid."""
+        return [
+            sid
+            for sid, session in self.storage.items()
+            if AuthnEvent.from_json(session["authn_event"]).uid == uid
+        ]
+
+    def get(self, attr: str, val: str) -> List[str]:
+        """Return session ids based on attribute name and value."""
+        return [
+            sid for sid, session in self.storage.items() if session.get(attr) == val
+        ]
+
+    def get_uid_by_sub(self, sub):
+        """Return User ids based on sub. Should only be one."""
+        for sid, session in self.storage.items():
+            if session.get("sub") == sub:
+                return AuthnEvent.from_json(session["authn_event"]).uid
+        return None
+
+    def get_uid_by_sid(self, sid):
+        return self.get_uid_by_sub(self.storage[sid]["sub"])
+
+    def get_by_sub_and_(self, sub, key, val):
+        """
+        Given a subject identifier and a key/value pair return the Id of a session
+        that matches those values.
+
+        :param sub: Subjecty Identifier
+        :param key: attribute name
+        :param val: attribute value
+        :return: Session identifier
+        """
+        for sid, session in self.storage.items():
+            if session.get("sub") == sub and session.get(key) == val:
+                return sid
+
+    def update(self, key, attribute, value):
+        """
+        Updates information stored. If the key is not know a new entry will be
+        constructed.
+
+        :param key: Key to the database
+        :param attribute: Attribute name
+        :param value: Attribute value
+        """
+        if key not in self.storage:
+            self.storage[key] = {attribute: value}
+        else:
+            item = self.storage[key]
+            item[attribute] = value
+            self.storage[key] = item
+
+
+def session_update(db, key, attr, val):
+    if isinstance(db, SessionBackend):
+        db.update(key, attr, val)
+    elif isinstance(db, dict):
+        item = db[key]
+        item[attr] = val
+        db[key] = item
+    else:
+        raise ValueError("Unknown session database type")
+
+
+def session_get(db, attr, val):
+    """Return session ID based on attribute having value val"""
+    if isinstance(db, SessionBackend):
+        db.get(attr, val)
+    elif isinstance(db, dict):
+        for _key, _val in db.items():
+            try:
+                if _val[attr] == val:
+                    return _key
+            except KeyError:
+                continue
+        return None
+    else:
+        raise ValueError("Unknown session database type")
+
+
+def session_extended_get(db, sub, attr, val):
+    """Return session ID based on subject_id and attribute attr having value val"""
+    if isinstance(db, SessionBackend):
+        for sid in db.get_by_sub(sub):
+            try:
+                if db[sid][attr] == val:
+                    return sid
+            except KeyError:
+                continue
+        return None
+    elif isinstance(db, dict):
+        for _key, _val in db.items():
+            try:
+                if _val['sub'] == sub and _val[attr] == val:
+                    return _key
+            except KeyError:
+                continue
+        return None
+    else:
+        raise ValueError("Unknown session database type")
+
+
+def session_set(db, attr, val):
+    if isinstance(db, SessionBackend):
+        db[attr] = val
+    elif isinstance(db, dict):
+        db[attr] = val
+    else:
+        raise ValueError("Unknown session database type")

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -11,14 +11,14 @@ from oic.utils.time_util import time_sans_frac
 
 class AuthnEvent(object):
     def __init__(
-            self,
-            uid,
-            salt,
-            valid=3600,
-            authn_info=None,
-            time_stamp=0,
-            authn_time=None,
-            valid_until=None,
+        self,
+        uid,
+        salt,
+        valid=3600,
+        authn_info=None,
+        time_stamp=0,
+        authn_time=None,
+        valid_until=None,
     ):
         """
         Create a representation of an authentication event.
@@ -275,7 +275,7 @@ def session_extended_get(db, sub, attr, val):
     elif isinstance(db, dict):
         for _key, _val in db.items():
             try:
-                if _val['sub'] == sub and _val[attr] == val:
+                if _val["sub"] == sub and _val[attr] == val:
                     return _key
             except KeyError:
                 continue

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -127,16 +127,11 @@ class SessionBackend(metaclass=ABCMeta):
             item[attribute] = value
             self[key] = item
 
-    def get_uid_by_sub(self, sub: str) -> str:
+    def get_uid_by_sub(self, sub: str) -> Optional[str]:
         """Return User id based on sub."""
-        uid = ""
         for sid in self.get_by_sub(sub):
-            if uid:
-                if uid != AuthnEvent.from_json(self[sid]["authn_event"]).uid:
-                    raise ValueError("More the one uid bound to one sub")
-            else:
-                uid = AuthnEvent.from_json(self[sid]["authn_event"]).uid
-        return uid
+            return AuthnEvent.from_json(self[sid]["authn_event"]).uid
+        return None
 
     def get_uid_by_sid(self, sid: str) -> str:
         """Return User id based on session ID."""

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -113,7 +113,7 @@ class SessionBackend(metaclass=ABCMeta):
         # We do not care which session it is - once revoked, al are revoked
         return any([self[sid]["revoked"] for sid in self.get_by_uid(uid)])
 
-    def update(self, key: str, attribute: str, value: Any) -> NoReturn:
+    def update(self, key: str, attribute: str, value: Any):
         """
         Updates information stored. If the key is not know a new entry will be
         constructed.

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -5,7 +5,6 @@ from abc import abstractmethod
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import NoReturn
 from typing import Optional
 
 from oic.utils.time_util import time_sans_frac
@@ -115,8 +114,7 @@ class SessionBackend(metaclass=ABCMeta):
 
     def update(self, key: str, attribute: str, value: Any):
         """
-        Updates information stored. If the key is not know a new entry will be
-        constructed.
+        Updates information stored. If the key is not know a new entry will be constructed.
 
         :param key: Key to the database
         :param attribute: Attribute name
@@ -141,7 +139,7 @@ class SessionBackend(metaclass=ABCMeta):
         return uid
 
     def get_uid_by_sid(self, sid):
-        """Return session ids based on uid"""
+        """Return session ids based on uid."""
         return AuthnEvent.from_json(self[sid]["authn_event"]).uid
 
 

--- a/src/oic/utils/session_backend.py
+++ b/src/oic/utils/session_backend.py
@@ -128,7 +128,7 @@ class SessionBackend(metaclass=ABCMeta):
             self[key] = item
 
     def get_uid_by_sub(self, sub: str) -> str:
-        """Return User ids based on sub. Should only be one."""
+        """Return User id based on sub."""
         uid = ""
         for sid in self.get_by_sub(sub):
             if uid:

--- a/src/oic/utils/userinfo/aa_info.py
+++ b/src/oic/utils/userinfo/aa_info.py
@@ -22,7 +22,10 @@ else:
             # Configurations for the SP handler. (pyOpSamlProxy.client.sp.conf)
             self.sp_conf = importlib.import_module(spconf)
             ntf = NamedTemporaryFile(suffix="pyoidc.py", delete=True)
-            ntf.write(b"CONFIG = " + self.sp_conf.CONFIG.replace("%s", url))
+            ntf.write(
+                "CONFIG = "  # type: ignore
+                + str(self.sp_conf.CONFIG).replace("%s", url)
+            )
             ntf.seek(0)
             self.sp = Saml2Client(config_file="%s" % ntf.name)
             self.samlcache = self.sp_conf.SAML_CACHE

--- a/src/oic/utils/userinfo/aa_info.py
+++ b/src/oic/utils/userinfo/aa_info.py
@@ -22,7 +22,7 @@ else:
             # Configurations for the SP handler. (pyOpSamlProxy.client.sp.conf)
             self.sp_conf = importlib.import_module(spconf)
             ntf = NamedTemporaryFile(suffix="pyoidc.py", delete=True)
-            ntf.write("CONFIG = " + str(self.sp_conf.CONFIG).replace("%s", url))
+            ntf.write(b"CONFIG = " + self.sp_conf.CONFIG.replace("%s", url))
             ntf.seek(0)
             self.sp = Saml2Client(config_file="%s" % ntf.name)
             self.samlcache = self.sp_conf.SAML_CACHE

--- a/tests/test_oauth2_consumer.py
+++ b/tests/test_oauth2_consumer.py
@@ -128,20 +128,25 @@ class TestConsumer(object):
     @pytest.fixture(autouse=True)
     def create_consumer(self):
         self.consumer = Consumer(
-            DictSessionBackend(), client_config=CLIENT_CONFIG,
-            server_info=SERVER_INFO, **CONSUMER_CONFIG
+            DictSessionBackend(),
+            client_config=CLIENT_CONFIG,
+            server_info=SERVER_INFO,
+            **CONSUMER_CONFIG
         )
 
     def test_init(self):
         cons = Consumer(
-            DictSessionBackend(), client_config=CLIENT_CONFIG,
-            server_info=SERVER_INFO, **CONSUMER_CONFIG
+            DictSessionBackend(),
+            client_config=CLIENT_CONFIG,
+            server_info=SERVER_INFO,
+            **CONSUMER_CONFIG
         )
         cons._backup("123456")
         assert "123456" in cons.sdb
 
-        cons = Consumer(DictSessionBackend(), client_config=CLIENT_CONFIG,
-            **CONSUMER_CONFIG)
+        cons = Consumer(
+            DictSessionBackend(), client_config=CLIENT_CONFIG, **CONSUMER_CONFIG
+        )
         assert cons.authorization_endpoint is None
 
         cons = Consumer(DictSessionBackend, **CONSUMER_CONFIG)

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -9,9 +9,6 @@ from freezegun import freeze_time
 from jwkest import BadSignature
 from jwkest.jwk import SYMKey
 
-from oic.utils.sdb import session_get
-from oic.utils.time_util import utc_time_sans_frac
-
 from oic.oauth2.message import MissingSigningKey
 from oic.oic import DEF_SIGN_ALG
 from oic.oic import Server
@@ -29,6 +26,8 @@ from oic.utils.keyio import KeyBundle
 from oic.utils.keyio import KeyJar
 from oic.utils.keyio import keybundle_from_local_file
 from oic.utils.sdb import DictSessionBackend
+from oic.utils.sdb import session_get
+from oic.utils.time_util import utc_time_sans_frac
 
 __author__ = "rohe0002"
 
@@ -855,10 +854,10 @@ class TestOICConsumer:
             "nonce": "KUEYfRM2VzKDaaKD",
             "sub": "EndUserSubject",
             "iss": "https://example.com",
-            "exp": now+3600,
+            "exp": now + 3600,
             "iat": now,
             "aud": self.consumer.client_id,
-            "sid": smid
+            "sid": smid,
         }
         idts = IdToken(**idval)
 
@@ -867,7 +866,7 @@ class TestOICConsumer:
         _state = "state"
         self.consumer.sdb[_state] = {"redirect_uris": ["https://example.org/cb"]}
         resp = AuthorizationResponse(id_token=_signed_jwt, state=_state)
-        self.consumer.consumer_config['response_type'] = ["id_token"]
+        self.consumer.consumer_config["response_type"] = ["id_token"]
         part = self.consumer.parse_authz(resp.to_urlencoded())
-        assert self.consumer.sso_db.storage['state']['smid'] == smid
+        assert self.consumer.sso_db.storage["state"]["smid"] == smid
         assert session_get(self.consumer.sso_db, "smid", smid) == [_state]

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -867,6 +867,6 @@ class TestOICConsumer:
         self.consumer.sdb[_state] = {"redirect_uris": ["https://example.org/cb"]}
         resp = AuthorizationResponse(id_token=_signed_jwt, state=_state)
         self.consumer.consumer_config["response_type"] = ["id_token"]
-        part = self.consumer.parse_authz(resp.to_urlencoded())
+        self.consumer.parse_authz(resp.to_urlencoded())
         assert self.consumer.sso_db.storage["state"]["smid"] == smid
         assert session_get(self.consumer.sso_db, "smid", smid) == [_state]

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -9,6 +9,9 @@ from freezegun import freeze_time
 from jwkest import BadSignature
 from jwkest.jwk import SYMKey
 
+from oic.utils.sdb import session_get
+from oic.utils.time_util import utc_time_sans_frac
+
 from oic.oauth2.message import MissingSigningKey
 from oic.oic import DEF_SIGN_ALG
 from oic.oic import Server
@@ -844,3 +847,27 @@ class TestOICConsumer:
         query = urlparse(result.headers["location"]).query
         with pytest.raises(BadSignature):
             self.consumer.parse_authz(query=query)
+
+    def test_get_session_management_id(self):
+        now = utc_time_sans_frac()
+        smid = "session_management_id"
+        idval = {
+            "nonce": "KUEYfRM2VzKDaaKD",
+            "sub": "EndUserSubject",
+            "iss": "https://example.com",
+            "exp": now+3600,
+            "iat": now,
+            "aud": self.consumer.client_id,
+            "sid": smid
+        }
+        idts = IdToken(**idval)
+
+        _signed_jwt = idts.to_jwt(key=KC_RSA.keys(), algorithm="RS256")
+
+        _state = "state"
+        self.consumer.sdb[_state] = {"redirect_uris": ["https://example.org/cb"]}
+        resp = AuthorizationResponse(id_token=_signed_jwt, state=_state)
+        self.consumer.consumer_config['response_type'] = ["id_token"]
+        part = self.consumer.parse_authz(resp.to_urlencoded())
+        assert self.consumer.sso_db.storage['state']['smid'] == smid
+        assert session_get(self.consumer.sso_db, "smid", smid) == [_state]

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -132,10 +132,7 @@ class TestOICConsumer:
         }
 
         self.consumer = Consumer(
-            DictSessionBackend(),
-            CONFIG,
-            client_config,
-            SERVER_INFO,
+            DictSessionBackend(), CONFIG, client_config, SERVER_INFO
         )
         self.consumer.behaviour = {
             "request_object_signing_alg": DEF_SIGN_ALG["openid_request_object"]

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -1,6 +1,8 @@
 import os
 from time import time
 from typing import Any
+from typing import Any
+from typing import Dict
 from typing import Dict
 
 import pytest
@@ -268,7 +270,7 @@ class TestOICConsumerLogout:
 
     def test_logout_with_none(self):
         # Now, for the backchannel logout. This happens on the OP
-        logout_info = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
+        logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
         alg = "RS256"
         _jws = JWT(
             self.provider.keyjar,

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from time import time
 from typing import Any
 from typing import Dict
@@ -271,9 +272,14 @@ class TestOICConsumerLogout:
     def test_logout_with_none(self):
         # Now for the backchannel logout. This happens on the OP
 
-        logout_info = {
-            "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
-        }  # type: Dict[str, Dict[str, Dict[Any, Any]]]
+        if sys.version_info >= (3, 6):
+            logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {
+                "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
+            }
+        else:
+            logout_info = {
+                "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
+            }  # type: Dict[str, Dict[str, Dict[Any, Any]]]
 
         alg = "RS256"
         _jws = JWT(

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -202,6 +202,11 @@ class TestOICConsumerLogout:
 
         assert _sid == sid
 
+        # Test other coding
+        _sid = self.consumer.backchannel_logout(request=request.to_urlencoded())
+        assert _sid == sid
+
+
     def test_not_for_me(self):
         _sub = "sub"
 
@@ -290,3 +295,4 @@ class TestOICConsumerLogout:
         # value) is returned.
         with pytest.raises(MessageException):
             _ = self.consumer.backchannel_logout(request_args=request.to_dict())
+

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -270,9 +270,9 @@ class TestOICConsumerLogout:
         assert _sid == [sid]
 
     def test_logout_with_none(self):
-        # Now, for the backchannel logout. This happens on the OP
-        # Python version 3.5 doesn't support variable annotation
-        if sys.version_info > (3, 5):
+        # Now for the backchannel logout. This happens on the OP
+        # Pgitython version 3.5 doesn't support variable annotation
+        if sys.version_info >= (3, 6):
             logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
         else:
             logout_info = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -272,7 +272,7 @@ class TestOICConsumerLogout:
     def test_logout_with_none(self):
         # Now for the backchannel logout. This happens on the OP
 
-        if sys.version_info >= (3, 6):
+        if sys.version_info[:2] >= (3, 6):
             logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {
                 "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
             }

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -7,9 +7,9 @@ from oic import rndstr
 from oic.exception import MessageException
 from oic.oic import AccessTokenResponse
 from oic.oic.consumer import Consumer
+from oic.oic.message import BACK_CHANNEL_LOGOUT_EVENT
 from oic.oic.message import AccessTokenRequest
 from oic.oic.message import AuthorizationRequest
-from oic.oic.message import BACK_CHANNEL_LOGOUT_EVENT
 from oic.oic.message import BackChannelLogoutRequest
 from oic.oic.provider import Provider
 from oic.utils.authn.authn_context import AuthnBroker
@@ -203,10 +203,7 @@ class TestOICConsumerLogout:
     def test_not_for_me(self):
         _sub = "sub"
 
-        logout_info = {
-            "sub": _sub,
-            "events": {BACK_CHANNEL_LOGOUT_EVENT: {}},
-        }
+        logout_info = {"sub": _sub, "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
         alg = "RS256"
         _jws = JWT(
             self.provider.keyjar,
@@ -242,16 +239,15 @@ class TestOICConsumerLogout:
             grant_type="authorization_code",
         )
         token_resp = self.provider.code_grant_type(areq)
-        self.consumer.parse_response(AccessTokenResponse, token_resp.message, sformat="json")
+        self.consumer.parse_response(
+            AccessTokenResponse, token_resp.message, sformat="json"
+        )
         # Have to fake this until the provider changes are in place
         _smid = "session_management_id"
         self.consumer.sso_db.update(sid, "smid", _smid)
 
         # Now, for the backchannel logout. This happens on the OP
-        logout_info = {
-            "sid": _smid,
-            "events": {BACK_CHANNEL_LOGOUT_EVENT: {}},
-        }
+        logout_info = {"sid": _smid, "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
         alg = "RS256"
         _jws = JWT(
             self.provider.keyjar,
@@ -273,9 +269,7 @@ class TestOICConsumerLogout:
 
     def test_logout_with_none(self):
         # Now, for the backchannel logout. This happens on the OP
-        logout_info = {
-            "events": {BACK_CHANNEL_LOGOUT_EVENT: {}},
-        }
+        logout_info = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
         alg = "RS256"
         _jws = JWT(
             self.provider.keyjar,

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -47,10 +47,8 @@ CONFIG = {
     "authz_page": "authz",
     "scope": ["openid"],
     "response_type": "code",
-    # "request_method": "parameter",
     "password": "hemligt",
     "max_age": 3600,
-    # "user_info": {"name": None},
 }
 
 # Provider information

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -1,0 +1,200 @@
+import os
+from time import time
+
+import pytest
+
+from oic import rndstr
+from oic.oic import AccessTokenResponse
+from oic.oic.consumer import Consumer
+from oic.oic.message import BACK_CHANNEL_LOGOUT_EVENT
+from oic.oic.message import AccessTokenRequest
+from oic.oic.message import AuthorizationRequest
+from oic.oic.message import BackChannelLogoutRequest
+from oic.oic.provider import Provider
+from oic.utils.authn.authn_context import AuthnBroker
+from oic.utils.authn.client import CLIENT_AUTHN_METHOD
+from oic.utils.authn.client import verify_client
+from oic.utils.authn.user import UserAuthnMethod
+from oic.utils.authz import AuthzHandling
+from oic.utils.jwt import JWT
+from oic.utils.keyio import KeyBundle
+from oic.utils.keyio import KeyJar
+from oic.utils.keyio import keybundle_from_local_file
+from oic.utils.sdb import DictSessionBackend
+from oic.utils.userinfo import UserInfo
+
+# -- CLIENT INFO ----
+
+CLIENT_ID = "client_1"
+ISSUER_ID = "https://example.org"
+
+KC_SYM_S = KeyBundle({"kty": "oct", "key": "abcdefghijklmnop", "use": "sig"})
+
+BASE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "data/keys"))
+KC_RSA = keybundle_from_local_file(
+    os.path.join(BASE_PATH, "rsa.key"), "rsa", ["ver", "sig"]
+)
+
+CLIKEYS = KeyJar()
+CLIKEYS[""] = [KC_RSA, KC_SYM_S]
+CLIKEYS[CLIENT_ID] = [KC_RSA, KC_SYM_S]
+CLIKEYS[ISSUER_ID] = [KC_RSA]
+
+CONFIG = {
+    "authz_page": "authz",
+    "scope": ["openid"],
+    "response_type": "code",
+    # "request_method": "parameter",
+    "password": "hemligt",
+    "max_age": 3600,
+    # "user_info": {"name": None},
+}
+
+# Provider information
+
+SERVER_INFO = {
+    "version": "3.0",
+    "issuer": ISSUER_ID,
+    "authorization_endpoint": "https://example.org/authorization",
+    "token_endpoint": "https://example.org/token",
+    "flows_supported": ["code", "token", "code token"],
+}
+
+SRVKEYS = KeyJar()
+SRVKEYS[""] = [KC_RSA]
+SRVKEYS[CLIENT_ID] = [KC_SYM_S, KC_RSA]
+SRVKEYS[ISSUER_ID] = [KC_SYM_S, KC_RSA]
+
+CDB = {
+    CLIENT_ID: {
+        "password": "hemligt",
+        "client_secret": "drickyoughurt",
+        "redirect_uris": [("https://example.com/authz", None)],
+        "post_logout_redirect_uris": [("https://example.com/post_logout", None)],
+        "client_salt": "salted",
+        "response_types": ["code"],
+    }
+}  # type: Dict[str, Dict[str, Any]]
+
+USERDB = {
+    "username": {
+        "name": "Linda Lindgren",
+        "nickname": "Linda",
+        "email": "linda@example.com",
+        "verified": True,
+        "sub": "username",
+        "extra_claim": "extra_claim_value",
+    }
+}
+
+URLMAP = {CLIENT_ID: ["https://example.com/authz"]}
+
+
+class DummyAuthn(UserAuthnMethod):
+    def __init__(self, srv, user):
+        UserAuthnMethod.__init__(self, srv)
+        self.user = user
+
+    def authenticated_as(self, cookie=None, **kwargs):
+        if cookie == "FAIL":
+            return None, 0
+        else:
+            return {"uid": self.user}, time()
+
+
+AUTHN_BROKER = AuthnBroker()
+AUTHN_BROKER.add("UNDEFINED", DummyAuthn(None, "username"))
+
+# dealing with authorization
+AUTHZ = AuthzHandling()
+SYMKEY = rndstr(16)  # symmetric key used to encrypt cookie info
+USERINFO = UserInfo(USERDB)
+
+# AUTHZ request
+
+AREQ = AuthorizationRequest(
+    response_type="code",
+    client_id=CLIENT_ID,
+    redirect_uri="https://example.com/authz",
+    scope=["openid"],
+    state="state000",
+)
+
+
+class TestOICConsumerLogout:
+    @pytest.fixture(autouse=True)
+    def setup_consumer(self, session_db_factory):
+        client_config = {
+            "client_id": CLIENT_ID,
+            "client_authn_method": CLIENT_AUTHN_METHOD,
+        }
+
+        self.consumer = Consumer(
+            DictSessionBackend(), CONFIG, client_config, SERVER_INFO
+        )
+        self.consumer.keyjar = CLIKEYS
+        self.consumer.redirect_uris = ["https://example.com/authz"]
+        self.consumer.client_secret = "hemlig"
+        self.consumer.secret_type = "basic"
+        self.consumer.issuer = ISSUER_ID
+
+        self.provider = Provider(
+            ISSUER_ID,
+            session_db_factory(ISSUER_ID),
+            CDB,
+            AUTHN_BROKER,
+            USERINFO,
+            AUTHZ,
+            verify_client,
+            SYMKEY,
+            urlmap=URLMAP,
+            keyjar=SRVKEYS,
+        )
+        self.provider.baseurl = self.provider.name
+
+    def test_logout(self):
+        # Simulate an authorization
+        sid, request_location = self.consumer.begin(
+            "openid", "code", path="https://example.com"
+        )
+        resp = self.provider.authorization_endpoint(request=request_location)
+        aresp = self.consumer.parse_authz(resp.message)
+
+        assert self.consumer.sdb[sid]["issuer"] == self.provider.baseurl
+
+        # Simulate an accesstoken request
+        areq = AccessTokenRequest(
+            code=aresp[0]["code"],
+            client_id=CLIENT_ID,
+            redirect_uri="http://example.com/authz",
+            client_secret=self.consumer.client_secret,
+            grant_type="authorization_code",
+        )
+        token_resp = self.provider.code_grant_type(areq)
+        tresp = self.consumer.parse_response(
+            AccessTokenResponse, token_resp.message, sformat="json"
+        )
+
+        # Now, for the backchannel logout. This happens on the OP
+        logout_info = {
+            "sub": tresp["id_token"]["sub"],
+            "events": {BACK_CHANNEL_LOGOUT_EVENT: {}},
+        }
+        alg = "RS256"
+        _jws = JWT(
+            self.provider.keyjar,
+            iss=self.provider.baseurl,
+            lifetime=86400,
+            sign_alg=alg,
+        )
+        _jws.with_jti = True
+        logout_token = _jws.pack(aud=CLIENT_ID, **logout_info)
+
+        # The logout request that gets sent to the RP
+        request = BackChannelLogoutRequest(logout_token=logout_token)
+
+        # The RP evaluates the request. If everything is OK a session ID (== original state
+        # value) is returned.
+        _sid = self.consumer.backchannel_logout(request_args=request.to_dict())
+
+        assert _sid == sid

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -1,8 +1,5 @@
 import os
-import sys
 from time import time
-from typing import Any
-from typing import Dict
 
 import pytest
 
@@ -14,6 +11,7 @@ from oic.oic.message import BACK_CHANNEL_LOGOUT_EVENT
 from oic.oic.message import AccessTokenRequest
 from oic.oic.message import AuthorizationRequest
 from oic.oic.message import BackChannelLogoutRequest
+from oic.oic.message import LogoutToken
 from oic.oic.provider import Provider
 from oic.utils.authn.authn_context import AuthnBroker
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
@@ -272,14 +270,7 @@ class TestOICConsumerLogout:
     def test_logout_with_none(self):
         # Now for the backchannel logout. This happens on the OP
 
-        if sys.version_info[:2] >= (3, 6):
-            logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {
-                "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
-            }
-        else:
-            logout_info = {
-                "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
-            }  # type: Dict[str, Dict[str, Dict[Any, Any]]]
+        logout_info = LogoutToken(events={BACK_CHANNEL_LOGOUT_EVENT: {}})
 
         alg = "RS256"
         _jws = JWT(

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -23,6 +23,7 @@ from oic.utils.keyio import KeyBundle
 from oic.utils.keyio import KeyJar
 from oic.utils.keyio import keybundle_from_local_file
 from oic.utils.sdb import DictSessionBackend
+from oic.utils.sdb import session_update
 from oic.utils.userinfo import UserInfo
 
 # -- CLIENT INFO ----
@@ -352,3 +353,8 @@ class TestOICConsumerLogout:
 
         with pytest.raises(AttributeError):
             getattr(self.consumer, "foo")
+
+
+def test_session_update():
+    with pytest.raises(KeyError):
+        session_update({}, "session_id", "attr", "val")

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -1,5 +1,7 @@
 import os
 from time import time
+from typing import Any
+from typing import Dict
 
 import pytest
 
@@ -273,7 +275,7 @@ class TestOICConsumerLogout:
 
         logout_info = {
             "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
-        }  # typing: Dict[str, Dict[str, Dict[Any, Any]]]
+        }  # type: Dict[str, Dict[str, Dict[Any, Any]]]
 
         alg = "RS256"
         _jws = JWT(

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -1,5 +1,7 @@
 import os
 from time import time
+from typing import Any
+from typing import Dict
 
 import pytest
 
@@ -188,7 +190,6 @@ class TestOICConsumerLogout:
             lifetime=86400,
             sign_alg=alg,
         )
-        _jws.with_jti = True
         logout_token = _jws.pack(aud=CLIENT_ID, **logout_info)
 
         # The logout request that gets sent to the RP
@@ -211,7 +212,6 @@ class TestOICConsumerLogout:
             lifetime=86400,
             sign_alg=alg,
         )
-        _jws.with_jti = True
         logout_token = _jws.pack(aud="someone", **logout_info)
 
         # The logout request that gets sent to the RP
@@ -255,7 +255,6 @@ class TestOICConsumerLogout:
             lifetime=86400,
             sign_alg=alg,
         )
-        _jws.with_jti = True
         logout_token = _jws.pack(aud=CLIENT_ID, **logout_info)
 
         # The logout request that gets sent to the RP
@@ -277,7 +276,6 @@ class TestOICConsumerLogout:
             lifetime=86400,
             sign_alg=alg,
         )
-        _jws.with_jti = True
         logout_token = _jws.pack(aud=CLIENT_ID, **logout_info)
 
         # The logout request that gets sent to the RP

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -2,8 +2,6 @@ import os
 import sys
 from time import time
 from typing import Any
-from typing import Any
-from typing import Dict
 from typing import Dict
 
 import pytest
@@ -271,9 +269,11 @@ class TestOICConsumerLogout:
 
     def test_logout_with_none(self):
         # Now for the backchannel logout. This happens on the OP
-        # Pgitython version 3.5 doesn't support variable annotation
+        # Python version 3.5 doesn't support variable annotation
         if sys.version_info >= (3, 6):
-            logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
+            logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {
+                "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
+            }
         else:
             logout_info = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
 

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from time import time
 from typing import Any
 from typing import Any
@@ -270,7 +271,12 @@ class TestOICConsumerLogout:
 
     def test_logout_with_none(self):
         # Now, for the backchannel logout. This happens on the OP
-        logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
+        # Python version 3.5 doesn't support variable annotation
+        if sys.version_info > (3, 5):
+            logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
+        else:
+            logout_info = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
+
         alg = "RS256"
         _jws = JWT(
             self.provider.keyjar,

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -269,13 +269,10 @@ class TestOICConsumerLogout:
 
     def test_logout_with_none(self):
         # Now for the backchannel logout. This happens on the OP
-        # Python version 3.5 doesn't support variable annotation
-        if sys.version_info >= (3, 6):
-            logout_info: Dict[str, Dict[str, Dict[Any, Any]]] = {
-                "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
-            }
-        else:
-            logout_info = {"events": {BACK_CHANNEL_LOGOUT_EVENT: {}}}
+
+        logout_info = {
+            "events": {BACK_CHANNEL_LOGOUT_EVENT: {}}
+        }  # typing: Dict[str, Dict[str, Dict[Any, Any]]]
 
         alg = "RS256"
         _jws = JWT(

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -206,7 +206,6 @@ class TestOICConsumerLogout:
         _sid = self.consumer.backchannel_logout(request=request.to_urlencoded())
         assert _sid == sid
 
-
     def test_not_for_me(self):
         _sub = "sub"
 
@@ -295,4 +294,3 @@ class TestOICConsumerLogout:
         # value) is returned.
         with pytest.raises(MessageException):
             _ = self.consumer.backchannel_logout(request_args=request.to_dict())
-

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -1,8 +1,5 @@
 import os
-import sys
 from time import time
-from typing import Any
-from typing import Dict
 
 import pytest
 
@@ -78,7 +75,7 @@ CDB = {
         "client_salt": "salted",
         "response_types": ["code"],
     }
-}  # type: Dict[str, Dict[str, Any]]
+}
 
 USERDB = {
     "username": {
@@ -223,7 +220,7 @@ class TestOICConsumerLogout:
         request = BackChannelLogoutRequest(logout_token=logout_token)
 
         with pytest.raises(MessageException):
-            _ = self.consumer.backchannel_logout(request_args=request.to_dict())
+            self.consumer.backchannel_logout(request_args=request.to_dict())
 
     def test_logout_without_sub(self):
         # Simulate an authorization
@@ -293,7 +290,7 @@ class TestOICConsumerLogout:
         # The RP evaluates the request. If everything is OK a session ID (== original state
         # value) is returned.
         with pytest.raises(MessageException):
-            _ = self.consumer.backchannel_logout(request_args=request.to_dict())
+            self.consumer.backchannel_logout(request_args=request.to_dict())
 
     def test_sso_db_dict(self):
         client_config = {

--- a/tests/test_oic_consumer_logout.py
+++ b/tests/test_oic_consumer_logout.py
@@ -353,8 +353,8 @@ class TestOICConsumerLogout:
         assert _sid == sid
 
     def test_attribute_error(self):
-        self.consumer.sdb.update('sid', 'foo', 'bar')
-        self.consumer.update('sid')
+        self.consumer.sdb.update("sid", "foo", "bar")
+        self.consumer.update("sid")
 
         with pytest.raises(AttributeError):
-            getattr(self.consumer, 'foo')
+            getattr(self.consumer, "foo")

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -212,7 +212,10 @@ class TestProvider(object):
         self.provider.baseurl = self.provider.name
 
         self.cons = Consumer(
-            DictSessionBackend(), CONSUMER_CONFIG.copy(), CLIENT_CONFIG, server_info=SERVER_INFO
+            DictSessionBackend(),
+            CONSUMER_CONFIG.copy(),
+            CLIENT_CONFIG,
+            server_info=SERVER_INFO,
         )
         self.cons.behaviour = {
             "request_object_signing_alg": DEF_SIGN_ALG["openid_request_object"]

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -2115,8 +2115,8 @@ class TestProvider(object):
         _sdb.upgrade_to_token(access_grant, issue_refresh=True)
 
         sub = _sdb[sid_2]["sub"]
-        assert self.provider.get_uid_by_sub(sub) == "user"
-        assert self.provider.get_uid_by_sid(sid_2) == "user"
+        assert self.provider.sdb.get_uid_by_sub(sub) == "user"
+        assert self.provider.sdb.get_uid_by_sid(sid_2) == "user"
 
         assert self.provider.get_by_sub_and_(sub, "client_id", "2ndClient") == sid_2
         assert self.provider.get_by_sub_and_(sub, "client_id", CLIENT_ID) == sid

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -2120,3 +2120,8 @@ class TestProvider(object):
 
         assert self.provider.get_by_sub_and_(sub, "client_id", "2ndClient") == sid_2
         assert self.provider.get_by_sub_and_(sub, "client_id", CLIENT_ID) == sid
+
+        # Error cases
+        assert self.provider.get_by_sub_and_(sub, "client_id", "unknown") is None
+        assert self.provider.get_by_sub_and_("who", "client_id", CLIENT_ID) is None
+        assert self.provider.get_by_sub_and_(sub, "foo", "bar") is None

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -2095,7 +2095,7 @@ class TestProvider(object):
             redirect_uri="http://example.com/authz",
             client_id=CLIENT_ID,
             response_type="code",
-            scope=["openid", "offline_access"]
+            scope=["openid", "offline_access"],
         )
 
         sid_2 = _sdb.access_token.key(user="sub", areq=authreq_2)

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -343,7 +343,7 @@ class TestDictSessionBackend(TestCase):
         aevent2 = AuthnEvent("my_uid", "some_salt").to_json()
         self.backend.update("key", "authn_event", aevent2)
         self.backend.update("key", "sub", "subject_id")
-        assert self.backend.get_uid_by_sid('key') == "my_uid"
+        assert self.backend.get_uid_by_sid("key") == "my_uid"
 
 
 class TestSessionDB(object):
@@ -634,8 +634,8 @@ class TestSessionDB(object):
 
         info = self.sdb[sid]
         assert (
-                info["sub"]
-                == "179670cdee6375c48e577317b2abd7d5cd26a5cdb1cfb7ef84af3d703c71d013"
+            info["sub"]
+            == "179670cdee6375c48e577317b2abd7d5cd26a5cdb1cfb7ef84af3d703c71d013"
         )
 
         self.sdb.do_sub(
@@ -646,8 +646,8 @@ class TestSessionDB(object):
         )
         info2 = self.sdb[sid]
         assert (
-                info2["sub"]
-                == "aaa50d80f8780cf1c4beb39e8e126556292f5091b9e39596424fefa2b99d9c53"
+            info2["sub"]
+            == "aaa50d80f8780cf1c4beb39e8e126556292f5091b9e39596424fefa2b99d9c53"
         )
 
         self.sdb.do_sub(
@@ -659,8 +659,8 @@ class TestSessionDB(object):
 
         info2 = self.sdb[sid]
         assert (
-                info2["sub"]
-                == "62fb630e29f0d41b88e049ac0ef49a9c3ac5418c029d6e4f5417df7e9443976b"
+            info2["sub"]
+            == "62fb630e29f0d41b88e049ac0ef49a9c3ac5418c029d6e4f5417df7e9443976b"
         )
 
     def test_get_authentication_event_dict(self):

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -30,7 +30,7 @@ AREQ = AuthorizationRequest(
     redirect_uri="http://example.com/authz",
     scope=["openid"],
     state="state000",
-)
+    )
 
 AREQN = AuthorizationRequest(
     response_type="code",
@@ -39,7 +39,7 @@ AREQN = AuthorizationRequest(
     scope=["openid"],
     state="state000",
     nonce="something",
-)
+    )
 
 AREQO = AuthorizationRequest(
     response_type="code",
@@ -48,7 +48,7 @@ AREQO = AuthorizationRequest(
     scope=["openid", "offlien_access"],
     prompt="consent",
     state="state000",
-)
+    )
 
 OIDR = OpenIDRequest(
     response_type="code",
@@ -56,7 +56,7 @@ OIDR = OpenIDRequest(
     redirect_uri="http://example.com/authz",
     scope=["openid"],
     state="state000",
-)
+    )
 
 
 def _eq(l1, l2):
@@ -83,7 +83,7 @@ class TestAuthnEvent(object):
             "authn_time": 1000,
             "valid_until": 1500,
             "authn_info": None,
-        }
+            }
 
 
 class TestDictRefreshDB(object):
@@ -94,14 +94,14 @@ class TestDictRefreshDB(object):
     def test_verify_token(self):
         token = self.rdb.create_token(
             "client1", "uid", "openid", "sub1", "authzreq", "sid"
-        )
+            )
         assert self.rdb.verify_token("client1", token)
         assert self.rdb.verify_token("client2", token) is False
 
     def test_revoke_token(self):
         token = self.rdb.create_token(
             "client1", "uid", "openid", "sub1", "authzreq", "sid"
-        )
+            )
         self.rdb.remove(token)
         assert self.rdb.verify_token("client1", token) is False
         with pytest.raises(KeyError):
@@ -112,7 +112,7 @@ class TestDictRefreshDB(object):
             self.rdb.get("token")
         token = self.rdb.create_token(
             "client1", "uid", ["openid"], "sub1", "authzreq", "sid"
-        )
+            )
         assert self.rdb.get(token) == {
             "client_id": "client1",
             "sub": "sub1",
@@ -120,7 +120,7 @@ class TestDictRefreshDB(object):
             "uid": "uid",
             "authzreq": "authzreq",
             "sid": "sid",
-        }
+            }
 
 
 class TestToken(object):
@@ -174,151 +174,137 @@ class TestToken(object):
 class TestSessionBackend(TestCase):
     """Unittests for SessionBackend - using the DictSessionBackend."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def create_backend(self):
         self.backend = DictSessionBackend()
 
     def test_setitem(self):
-        self.backend["key"] = "value"
-        self.assertEqual(self.backend.storage["key"], "value")
-        self.backend["key"] = "new_value"
-        self.assertEqual(self.backend.storage["key"], "new_value")
+        self.backend["key"] = {"foobar": "value"}
+        self.assertEqual(self.backend["key"], {"foobar": "value"})
+        self.backend["key"] = {"foobar": "new_value"}
+        self.assertEqual(self.backend["key"], {"foobar": "new_value"})
 
     def test_getitem(self):
-        self.backend.storage = {"key": "value"}
-        self.assertEqual(self.backend["key"], "value")
+        self.backend["key"] = {"foobar": "value"}
+        self.assertEqual(self.backend["key"], {"foobar": "value"})
         with self.assertRaises(KeyError):
             self.backend["missing"]
 
     def test_delitem(self):
-        self.backend.storage = {"key": "value"}
+        self.backend["key"] = {"foobar": "value"}
         del self.backend["key"]
         self.assertEqual(self.backend.storage, {})
 
     def test_contains(self):
-        self.backend["key"] = "value"
+        self.backend["key"] = {"foobar": "value"}
         self.assertTrue("key" in self.backend)
         self.assertFalse("missing" in self.backend)
 
     def test_get_by_sub(self):
-        self.backend.storage = {"session_id": {"sub": "my_sub"}}
+        self.backend["session_id"] = {"sub": "my_sub"}
         self.assertEqual(set(self.backend.get_by_sub("my_sub")), {"session_id"})
         self.assertEqual(set(self.backend.get_by_sub("missing")), set())
 
     def test_get_by_sub_multiple(self):
-        self.backend.storage = {
-            "session_id1": {"sub": "my_sub"},
-            "session_id2": {"sub": "my_sub"},
-        }
+        self.backend["session_id1"] = {"sub": "my_sub"}
+        self.backend["session_id2"] = {"sub": "my_sub"}
         self.assertEqual(
             set(self.backend.get_by_sub("my_sub")), {"session_id1", "session_id2"}
-        )
+            )
 
     def test_get_by_uid(self):
         aevent = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {"session_id": {"authn_event": aevent}}
+        self.backend["session_id"] = {"authn_event": aevent}
         self.assertEqual(set(self.backend.get_by_uid("my_uid")), {"session_id"})
         self.assertEqual(set(self.backend.get_by_uid("missing")), set())
 
     def test_get_by_uid_multiple(self):
         aevent1 = AuthnEvent("my_uid", "some_salt").to_json()
         aevent2 = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {
-            "session_id1": {"authn_event": aevent1},
-            "session_id2": {"authn_event": aevent2},
-        }
+        self.backend["session_id1"] = {"authn_event": aevent1}
+        self.backend["session_id2"] = {"authn_event": aevent2}
+
         self.assertEqual(
             set(self.backend.get_by_uid("my_uid")), {"session_id1", "session_id2"}
-        )
+            )
 
     def test_get_client_ids_for_uid(self):
         aevent = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {
-            "session_id": {"authn_event": aevent, "client_id": "my_client"}
-        }
+        self.backend["session_id"] = {"authn_event": aevent, "client_id": "my_client"}
         self.assertEqual(
             set(self.backend.get_client_ids_for_uid("my_uid")), {"my_client"}
-        )
+            )
         self.assertEqual(set(self.backend.get_client_ids_for_uid("missing")), set())
 
     def test_get_client_ids_for_uid_multiple(self):
         aevent1 = AuthnEvent("my_uid", "some_salt").to_json()
         aevent2 = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {
-            "session_id1": {"authn_event": aevent1, "client_id": "my_client"},
-            "session_id2": {"authn_event": aevent2, "client_id": "my_other"},
-        }
+        self.backend["session_id1"] = {"authn_event": aevent1, "client_id": "my_client"}
+        self.backend["session_id2"] = {"authn_event": aevent2, "client_id": "my_other"}
+
         self.assertEqual(
             set(self.backend.get_client_ids_for_uid("my_uid")),
             {"my_client", "my_other"},
-        )
+            )
 
     def test_get_verified_logout(self):
         aevent1 = AuthnEvent("my_uid1", "some_salt").to_json()
         aevent2 = AuthnEvent("my_uid2", "some_salt").to_json()
-        self.backend.storage = {
-            "session_id": {
-                "authn_event": aevent1,
-                "verified_logout": "verification key",
-            },
-            "session_id2": {"authn_event": aevent2},
-        }
+        self.backend["session_id"] = {
+            "authn_event": aevent1,
+            "verified_logout": "verification key"
+            }
+        self.backend["session_id2"] = {"authn_event": aevent2}
+
         self.assertEqual(
             self.backend.get_verified_logout("my_uid1"), "verification key"
-        )
+            )
         self.assertIsNone(self.backend.get_verified_logout("my_uid2"))
         self.assertIsNone(self.backend.get_verified_logout("missing"))
 
     def test_get_verified_logout_multiple(self):
         aevent1 = AuthnEvent("my_uid", "some_salt").to_json()
         aevent2 = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {
-            "session_id1": {
-                "authn_event": aevent1,
-                "verified_logout": "verification key",
-            },
-            "session_id2": {
-                "authn_event": aevent2,
-                "verified_logout": "verification key",
-            },
-        }
+        self.backend["session_id1"] = {
+            "authn_event": aevent1,
+            "verified_logout": "verification key"
+            }
+        self.backend["session_id2"] = {
+            "authn_event": aevent2,
+            "verified_logout": "verification key"
+            }
         self.assertEqual(self.backend.get_verified_logout("my_uid"), "verification key")
 
     def test_get_token_ids(self):
         aevent = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {
-            "session_id": {"authn_event": aevent, "id_token": "Id token"}
-        }
+        self.backend["session_id"] = {"authn_event": aevent, "id_token": "Id token"}
         self.assertEqual(set(self.backend.get_token_ids("my_uid")), {"Id token"})
         self.assertEqual(set(self.backend.get_token_ids("missing")), set())
 
     def test_get_token_ids_multiple(self):
         aevent1 = AuthnEvent("my_uid", "some_salt").to_json()
         aevent2 = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {
-            "session_id1": {"authn_event": aevent1, "id_token": "Id token 1"},
-            "session_id2": {"authn_event": aevent2, "id_token": "Id token 2"},
-        }
+        self.backend["session_id1"] = {"authn_event": aevent1, "id_token": "Id token 1"}
+        self.backend["session_id2"] = {"authn_event": aevent2, "id_token": "Id token 2"}
         self.assertEqual(
             set(self.backend.get_token_ids("my_uid")), {"Id token 1", "Id token 2"}
-        )
+            )
 
     def test_is_revoke_uid_false(self):
         aevent = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {"session_id": {"authn_event": aevent, "revoked": False}}
+        self.backend["session_id"] = {"authn_event": aevent, "revoked": False}
         self.assertFalse(self.backend.is_revoke_uid("my_uid"))
 
     def test_is_revoke_uid_true(self):
         aevent = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {"session_id": {"authn_event": aevent, "revoked": True}}
+        self.backend["session_id"] = {"authn_event": aevent, "revoked": True}
         self.assertTrue(self.backend.is_revoke_uid("my_uid"))
 
     def test_is_revoke_uid_multiple(self):
         aevent1 = AuthnEvent("my_uid", "some_salt").to_json()
         aevent2 = AuthnEvent("my_uid", "some_salt").to_json()
-        self.backend.storage = {
-            "session_id1": {"authn_event": aevent1, "revoked": True},
-            "session_id2": {"authn_event": aevent2, "revoked": False},
-        }
+        self.backend["session_id1"] = {"authn_event": aevent1, "revoked": True}
+        self.backend["session_id2"] = {"authn_event": aevent2, "revoked": False}
         self.assertTrue(self.backend.is_revoke_uid("my_uid"))
 
 
@@ -403,8 +389,8 @@ class TestSessionDB(object):
                 "access_token_scope",
                 "sub",
                 "response_type",
-            ],
-        )
+                ],
+            )
 
         # can't update again
         with pytest.raises(AccessCodeUsed):
@@ -438,8 +424,8 @@ class TestSessionDB(object):
                 "access_token_scope",
                 "refresh_token",
                 "sub",
-            ],
-        )
+                ],
+            )
 
         # can't update again
         with pytest.raises(AccessCodeUsed):
@@ -474,8 +460,8 @@ class TestSessionDB(object):
                 "oauth_state",
                 "access_token_scope",
                 "sub",
-            ],
-        )
+                ],
+            )
 
         assert _dict["id_token"] == "id_token"
         assert isinstance(_dict["oidreq"], OpenIDRequest)
@@ -599,7 +585,7 @@ class TestSessionDB(object):
         sub = self.sdb.do_sub(sid, "client_salt")
 
         # given the sub find out whether the authn event is still valid
-        sids = self.sdb.get_sids_by_sub(sub)
+        sids = self.sdb.get_by_sub(sub)
         ae = self.sdb[sids[0]]["authn_event"]
         assert AuthnEvent.from_json(ae).valid()
 
@@ -610,8 +596,8 @@ class TestSessionDB(object):
 
         info = self.sdb[sid]
         assert (
-            info["sub"]
-            == "179670cdee6375c48e577317b2abd7d5cd26a5cdb1cfb7ef84af3d703c71d013"
+                info["sub"]
+                == "179670cdee6375c48e577317b2abd7d5cd26a5cdb1cfb7ef84af3d703c71d013"
         )
 
         self.sdb.do_sub(
@@ -619,11 +605,11 @@ class TestSessionDB(object):
             "other_random_value",
             sector_id="http://example.com",
             subject_type="pairwise",
-        )
+            )
         info2 = self.sdb[sid]
         assert (
-            info2["sub"]
-            == "aaa50d80f8780cf1c4beb39e8e126556292f5091b9e39596424fefa2b99d9c53"
+                info2["sub"]
+                == "aaa50d80f8780cf1c4beb39e8e126556292f5091b9e39596424fefa2b99d9c53"
         )
 
         self.sdb.do_sub(
@@ -631,12 +617,12 @@ class TestSessionDB(object):
             "another_random_value",
             sector_id="http://other.example.com",
             subject_type="pairwise",
-        )
+            )
 
         info2 = self.sdb[sid]
         assert (
-            info2["sub"]
-            == "62fb630e29f0d41b88e049ac0ef49a9c3ac5418c029d6e4f5417df7e9443976b"
+                info2["sub"]
+                == "62fb630e29f0d41b88e049ac0ef49a9c3ac5418c029d6e4f5417df7e9443976b"
         )
 
     def test_get_authentication_event_dict(self):
@@ -646,7 +632,7 @@ class TestSessionDB(object):
             "salt": "salt",
             "authn_time": 1000,
             "valid_until": 1500,
-        }
+            }
         ae = self.sdb.get_authentication_event("123")
         assert ae.uid == "uid"
         assert ae.salt == "salt"
@@ -657,7 +643,7 @@ class TestSessionDB(object):
         self.sdb._db["123"] = {}
         self.sdb._db["123"]["authn_event"] = json.dumps(
             {"uid": "uid", "salt": "salt", "authn_time": 1000, "valid_until": 1500}
-        )
+            )
         ae = self.sdb.get_authentication_event("123")
         assert ae.uid == "uid"
         assert ae.salt == "salt"
@@ -673,63 +659,60 @@ class TestSessionDB(object):
         sdb1.do_sub(sid1, "salt")
         sid2 = sdb2.create_authz_session(ae, AREQ)
         sdb2.do_sub(sid2, "salt")
-        sdb1sids = sdb1.get_sids_from_uid("sub")
-        sdb2sids = sdb2.get_sids_from_uid("sub")
+        sdb1sids = sdb1.get_by_uid("sub")
+        sdb2sids = sdb2.get_by_uid("sub")
         assert sdb1sids == sdb2sids
 
     def test_get_client_ids_for_uid(self):
-        self.sdb._db["123"] = {
-            "authn_event": json.dumps({"uid": "my_uid", "salt": "salt"}),
-            "client_id": "my_client",
-        }
-        assert self.sdb.get_client_ids_for_uid("my_uid") == ["my_client"]
-
-    def test_get_verify_logout(self):
-        self.sdb._db["123"] = {
-            "authn_event": json.dumps({"uid": "my_uid", "salt": "salt"}),
-            "verified_logout": "something",
-        }
-        assert self.sdb.get_verify_logout("my_uid") == "something"
+        ae = AuthnEvent("my_uid", "salt")
+        sid2 = self.sdb.create_authz_session(ae, AREQ)
+        self.sdb.do_sub(sid2, "salt")
+        assert self.sdb.get_client_ids_for_uid("my_uid") == ["client1"]
 
     def test_set_verify_logout(self):
-        self.sdb._db["123"] = {
-            "authn_event": json.dumps({"uid": "my_uid", "salt": "salt"})
-        }
+        ae = AuthnEvent("my_uid", "salt")
+        sid2 = self.sdb.create_authz_session(ae, AREQ)
+        self.sdb.do_sub(sid2, "salt")
         self.sdb.set_verify_logout("my_uid")
         assert self.sdb.get_verify_logout("my_uid") is not None
+
+    def test_get_verify_logout(self):
+        ae = AuthnEvent("my_uid", "salt")
+        sid2 = self.sdb.create_authz_session(ae, AREQ)
+        self.sdb.do_sub(sid2, "salt")
+        self.sdb.set_verify_logout("my_uid")
+        assert self.sdb.get_verify_logout("my_uid")
+        assert set(self.sdb.get_verify_logout("my_uid").keys()) == {sid2}
 
     def test_set_verify_logout_multiple(self):
-        self.sdb._db["123"] = {
-            "authn_event": json.dumps({"uid": "my_uid", "salt": "salt"})
-        }
-        self.sdb._db["321"] = {
-            "authn_event": json.dumps({"uid": "my_uid", "salt": "salt"})
-        }
+        ae = AuthnEvent("my_uid", "salt")
+        sid1 = self.sdb.create_authz_session(ae, AREQ)
+        self.sdb.do_sub(sid1, "salt")
+        ae = AuthnEvent("my_uid", "salt")
+        sid2 = self.sdb.create_authz_session(ae, AREQ)
+        self.sdb.do_sub(sid2, "salt")
         self.sdb.set_verify_logout("my_uid")
         assert self.sdb.get_verify_logout("my_uid") is not None
-        assert (
-            self.sdb._db["123"]["verified_logout"]
-            == self.sdb._db["321"]["verified_logout"]
-        )
+        assert set(self.sdb.get_verify_logout("my_uid").keys()) == {sid1, sid2}
 
     def test_get_token_ids(self):
-        self.sdb._db["123"] = {
-            "authn_event": json.dumps({"uid": "my_uid", "salt": "salt"}),
-            "id_token": "Id token",
-        }
-        assert set(self.sdb.get_token_ids("my_uid")) == {"Id token"}
+        ae = AuthnEvent("my_uid", "salt")
+        sid1 = self.sdb.create_authz_session(ae, AREQ)
+        self.sdb.do_sub(sid1, "salt")
+        self.sdb.update(sid1, 'id_token', "Id token")
+        assert self.sdb.get_id_token("my_uid") == {"client1": "Id token"}
 
     def test_get_is_revoke_uid(self):
-        self.sdb._db["123"] = {
-            "authn_event": json.dumps({"uid": "my_uid", "salt": "salt"}),
-            "revoked": True,
-        }
+        ae = AuthnEvent("my_uid", "salt")
+        sid1 = self.sdb.create_authz_session(ae, AREQ)
+        self.sdb.do_sub(sid1, "salt")
+        self.sdb.update(sid1, "revoked", True)
         assert self.sdb.is_revoke_uid("my_uid")
 
     def test_revoke_uid(self):
-        self.sdb._db["123"] = {
-            "authn_event": json.dumps({"uid": "my_uid", "salt": "salt"})
-        }
+        ae = AuthnEvent("my_uid", "salt")
+        sid1 = self.sdb.create_authz_session(ae, AREQ)
+        self.sdb.do_sub(sid1, "salt")
         self.sdb.revoke_uid("my_uid")
         assert self.sdb.is_revoke_uid("my_uid")
 

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -30,7 +30,7 @@ AREQ = AuthorizationRequest(
     redirect_uri="http://example.com/authz",
     scope=["openid"],
     state="state000",
-    )
+)
 
 AREQN = AuthorizationRequest(
     response_type="code",
@@ -39,7 +39,7 @@ AREQN = AuthorizationRequest(
     scope=["openid"],
     state="state000",
     nonce="something",
-    )
+)
 
 AREQO = AuthorizationRequest(
     response_type="code",
@@ -48,7 +48,7 @@ AREQO = AuthorizationRequest(
     scope=["openid", "offlien_access"],
     prompt="consent",
     state="state000",
-    )
+)
 
 OIDR = OpenIDRequest(
     response_type="code",
@@ -56,7 +56,7 @@ OIDR = OpenIDRequest(
     redirect_uri="http://example.com/authz",
     scope=["openid"],
     state="state000",
-    )
+)
 
 
 def _eq(l1, l2):
@@ -83,7 +83,7 @@ class TestAuthnEvent(object):
             "authn_time": 1000,
             "valid_until": 1500,
             "authn_info": None,
-            }
+        }
 
 
 class TestDictRefreshDB(object):
@@ -94,14 +94,14 @@ class TestDictRefreshDB(object):
     def test_verify_token(self):
         token = self.rdb.create_token(
             "client1", "uid", "openid", "sub1", "authzreq", "sid"
-            )
+        )
         assert self.rdb.verify_token("client1", token)
         assert self.rdb.verify_token("client2", token) is False
 
     def test_revoke_token(self):
         token = self.rdb.create_token(
             "client1", "uid", "openid", "sub1", "authzreq", "sid"
-            )
+        )
         self.rdb.remove(token)
         assert self.rdb.verify_token("client1", token) is False
         with pytest.raises(KeyError):
@@ -112,7 +112,7 @@ class TestDictRefreshDB(object):
             self.rdb.get("token")
         token = self.rdb.create_token(
             "client1", "uid", ["openid"], "sub1", "authzreq", "sid"
-            )
+        )
         assert self.rdb.get(token) == {
             "client_id": "client1",
             "sub": "sub1",
@@ -120,7 +120,7 @@ class TestDictRefreshDB(object):
             "uid": "uid",
             "authzreq": "authzreq",
             "sid": "sid",
-            }
+        }
 
 
 class TestToken(object):
@@ -171,7 +171,7 @@ class TestToken(object):
         assert factory.is_expired(token, when=when) is True
 
 
-class TestSessionBackend(TestCase):
+class TestDictSessionBackend(TestCase):
     """Unittests for SessionBackend - using the DictSessionBackend."""
 
     @pytest.fixture(autouse=True)
@@ -210,7 +210,7 @@ class TestSessionBackend(TestCase):
         self.backend["session_id2"] = {"sub": "my_sub"}
         self.assertEqual(
             set(self.backend.get_by_sub("my_sub")), {"session_id1", "session_id2"}
-            )
+        )
 
     def test_get_by_uid(self):
         aevent = AuthnEvent("my_uid", "some_salt").to_json()
@@ -226,14 +226,14 @@ class TestSessionBackend(TestCase):
 
         self.assertEqual(
             set(self.backend.get_by_uid("my_uid")), {"session_id1", "session_id2"}
-            )
+        )
 
     def test_get_client_ids_for_uid(self):
         aevent = AuthnEvent("my_uid", "some_salt").to_json()
         self.backend["session_id"] = {"authn_event": aevent, "client_id": "my_client"}
         self.assertEqual(
             set(self.backend.get_client_ids_for_uid("my_uid")), {"my_client"}
-            )
+        )
         self.assertEqual(set(self.backend.get_client_ids_for_uid("missing")), set())
 
     def test_get_client_ids_for_uid_multiple(self):
@@ -245,20 +245,20 @@ class TestSessionBackend(TestCase):
         self.assertEqual(
             set(self.backend.get_client_ids_for_uid("my_uid")),
             {"my_client", "my_other"},
-            )
+        )
 
     def test_get_verified_logout(self):
         aevent1 = AuthnEvent("my_uid1", "some_salt").to_json()
         aevent2 = AuthnEvent("my_uid2", "some_salt").to_json()
         self.backend["session_id"] = {
             "authn_event": aevent1,
-            "verified_logout": "verification key"
-            }
+            "verified_logout": "verification key",
+        }
         self.backend["session_id2"] = {"authn_event": aevent2}
 
         self.assertEqual(
             self.backend.get_verified_logout("my_uid1"), "verification key"
-            )
+        )
         self.assertIsNone(self.backend.get_verified_logout("my_uid2"))
         self.assertIsNone(self.backend.get_verified_logout("missing"))
 
@@ -267,12 +267,12 @@ class TestSessionBackend(TestCase):
         aevent2 = AuthnEvent("my_uid", "some_salt").to_json()
         self.backend["session_id1"] = {
             "authn_event": aevent1,
-            "verified_logout": "verification key"
-            }
+            "verified_logout": "verification key",
+        }
         self.backend["session_id2"] = {
             "authn_event": aevent2,
-            "verified_logout": "verification key"
-            }
+            "verified_logout": "verification key",
+        }
         self.assertEqual(self.backend.get_verified_logout("my_uid"), "verification key")
 
     def test_get_token_ids(self):
@@ -288,7 +288,7 @@ class TestSessionBackend(TestCase):
         self.backend["session_id2"] = {"authn_event": aevent2, "id_token": "Id token 2"}
         self.assertEqual(
             set(self.backend.get_token_ids("my_uid")), {"Id token 1", "Id token 2"}
-            )
+        )
 
     def test_is_revoke_uid_false(self):
         aevent = AuthnEvent("my_uid", "some_salt").to_json()
@@ -389,8 +389,8 @@ class TestSessionDB(object):
                 "access_token_scope",
                 "sub",
                 "response_type",
-                ],
-            )
+            ],
+        )
 
         # can't update again
         with pytest.raises(AccessCodeUsed):
@@ -424,8 +424,8 @@ class TestSessionDB(object):
                 "access_token_scope",
                 "refresh_token",
                 "sub",
-                ],
-            )
+            ],
+        )
 
         # can't update again
         with pytest.raises(AccessCodeUsed):
@@ -460,8 +460,8 @@ class TestSessionDB(object):
                 "oauth_state",
                 "access_token_scope",
                 "sub",
-                ],
-            )
+            ],
+        )
 
         assert _dict["id_token"] == "id_token"
         assert isinstance(_dict["oidreq"], OpenIDRequest)
@@ -596,8 +596,8 @@ class TestSessionDB(object):
 
         info = self.sdb[sid]
         assert (
-                info["sub"]
-                == "179670cdee6375c48e577317b2abd7d5cd26a5cdb1cfb7ef84af3d703c71d013"
+            info["sub"]
+            == "179670cdee6375c48e577317b2abd7d5cd26a5cdb1cfb7ef84af3d703c71d013"
         )
 
         self.sdb.do_sub(
@@ -605,11 +605,11 @@ class TestSessionDB(object):
             "other_random_value",
             sector_id="http://example.com",
             subject_type="pairwise",
-            )
+        )
         info2 = self.sdb[sid]
         assert (
-                info2["sub"]
-                == "aaa50d80f8780cf1c4beb39e8e126556292f5091b9e39596424fefa2b99d9c53"
+            info2["sub"]
+            == "aaa50d80f8780cf1c4beb39e8e126556292f5091b9e39596424fefa2b99d9c53"
         )
 
         self.sdb.do_sub(
@@ -617,12 +617,12 @@ class TestSessionDB(object):
             "another_random_value",
             sector_id="http://other.example.com",
             subject_type="pairwise",
-            )
+        )
 
         info2 = self.sdb[sid]
         assert (
-                info2["sub"]
-                == "62fb630e29f0d41b88e049ac0ef49a9c3ac5418c029d6e4f5417df7e9443976b"
+            info2["sub"]
+            == "62fb630e29f0d41b88e049ac0ef49a9c3ac5418c029d6e4f5417df7e9443976b"
         )
 
     def test_get_authentication_event_dict(self):
@@ -632,7 +632,7 @@ class TestSessionDB(object):
             "salt": "salt",
             "authn_time": 1000,
             "valid_until": 1500,
-            }
+        }
         ae = self.sdb.get_authentication_event("123")
         assert ae.uid == "uid"
         assert ae.salt == "salt"
@@ -643,7 +643,7 @@ class TestSessionDB(object):
         self.sdb._db["123"] = {}
         self.sdb._db["123"]["authn_event"] = json.dumps(
             {"uid": "uid", "salt": "salt", "authn_time": 1000, "valid_until": 1500}
-            )
+        )
         ae = self.sdb.get_authentication_event("123")
         assert ae.uid == "uid"
         assert ae.salt == "salt"
@@ -699,7 +699,7 @@ class TestSessionDB(object):
         ae = AuthnEvent("my_uid", "salt")
         sid1 = self.sdb.create_authz_session(ae, AREQ)
         self.sdb.do_sub(sid1, "salt")
-        self.sdb.update(sid1, 'id_token', "Id token")
+        self.sdb.update(sid1, "id_token", "Id token")
         assert self.sdb.get_id_token("my_uid") == {"client1": "Id token"}
 
     def test_get_is_revoke_uid(self):

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -720,7 +720,6 @@ class TestSessionDB(object):
         self.sdb.do_sub(sid2, "salt")
         self.sdb.set_verify_logout("my_uid")
         assert self.sdb.get_verify_logout("my_uid")
-        assert set(self.sdb.get_verify_logout("my_uid").keys()) == {sid2}
 
     def test_set_verify_logout_multiple(self):
         ae = AuthnEvent("my_uid", "salt")
@@ -731,7 +730,6 @@ class TestSessionDB(object):
         self.sdb.do_sub(sid2, "salt")
         self.sdb.set_verify_logout("my_uid")
         assert self.sdb.get_verify_logout("my_uid") is not None
-        assert set(self.sdb.get_verify_logout("my_uid").keys()) == {sid1, sid2}
 
     def test_get_token_ids(self):
         ae = AuthnEvent("my_uid", "salt")

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -196,7 +196,7 @@ class TestDictSessionBackend(TestCase):
         self.backend["key"] = {"foobar": "value"}
         self.assertEqual(self.backend["key"], {"foobar": "value"})
         with self.assertRaises(KeyError):
-            _ = self.backend["missing"]
+            self.backend["missing"]
 
     def test_delitem(self):
         self.backend["key"] = {"foobar": "value"}

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -731,13 +731,6 @@ class TestSessionDB(object):
         self.sdb.set_verify_logout("my_uid")
         assert self.sdb.get_verify_logout("my_uid") is not None
 
-    def test_get_token_ids(self):
-        ae = AuthnEvent("my_uid", "salt")
-        sid1 = self.sdb.create_authz_session(ae, AREQ)
-        self.sdb.do_sub(sid1, "salt")
-        self.sdb.update(sid1, "id_token", "Id token")
-        assert self.sdb.get_id_token("my_uid") == {"client1": "Id token"}
-
     def test_get_is_revoke_uid(self):
         ae = AuthnEvent("my_uid", "salt")
         sid1 = self.sdb.create_authz_session(ae, AREQ)

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -493,7 +493,7 @@ class TestSessionDB(object):
         sub = self.sdb.do_sub(sid, "client_salt")
 
         # given the sub find out whether the authn event is still valid
-        sids = self.sdb.get_sids_by_sub(sub)
+        sids = self.sdb.get_by_sub(sub)
         ae = self.sdb[sids[0]]["authn_event"]
         assert AuthnEvent.from_json(ae).valid()
 

--- a/tests/test_x_provider.py
+++ b/tests/test_x_provider.py
@@ -25,6 +25,7 @@ from oic.utils.authz import Implicit
 from oic.utils.keyio import KeyBundle
 from oic.utils.keyio import KeyJar
 from oic.utils.sdb import DefaultToken
+from oic.utils.sdb import DictSessionBackend
 from oic.utils.sdb import SessionDB
 from oic.utils.sdb import lv_pack
 from oic.utils.sdb import lv_unpack
@@ -146,7 +147,7 @@ class TestProvider(object):
 
         _sdb = SessionDB(
             "https://example.com/",
-            db={},
+            db=DictSessionBackend(),
             code_factory=DefaultToken(
                 "supersecret", "verybadpassword", typ="A", lifetime=600
             ),


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [x] New code is annotated.
- [x] Changes are covered by tests.
---

This is step 2 of adding single sign out to pyoidc. This part includes changes to session databases used by OPs and RPs and necessary changes to the OIDC Consumer class.