### PR TITLE
'state' in kwargs MUST NOT overwrite 'state' in request_args.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on the [KeepAChangeLog] project.
 - [#602] Fixed uncaught error on unpacking of message
 - [#679] Make `state` optional in `EndSessionRequest`
 - [#683] Fix basic_auth with client password
+- [#698] `state` in `EndSessionRequest` request args and kwargs different
 
 ### Removed
 - [#671] Removed deprecated request/response_cls kwargs from Provider/Client methods
@@ -26,6 +27,7 @@ The format is based on the [KeepAChangeLog] project.
 [#679]: https://github.com/OpenIDC/pyoidc/pull/679
 [#683]: https://github.com/OpenIDC/pyoidc/issues/683
 [#688]: https://github.com/OpenIDC/pyoidc/pull/688
+[#698]: https://github.com/OpenIDC/pyoidc/pull/698
 
 ## 1.0.1 [2019-06-30]
 

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -628,7 +628,7 @@ class Client(oauth2.Client):
         if request_args is None:
             request_args = {}
 
-        if "state" in request_args and 'state' not in kwargs:
+        if "state" in request_args and "state" not in kwargs:
             kwargs["state"] = request_args["state"]
 
         return self._id_token_based(request, request_args, extra_args, **kwargs)

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -628,9 +628,7 @@ class Client(oauth2.Client):
         if request_args is None:
             request_args = {}
 
-        if "state" in kwargs:
-            request_args["state"] = kwargs["state"]
-        elif "state" in request_args:
+        if "state" in request_args and 'state' not in kwargs:
             kwargs["state"] = request_args["state"]
 
         return self._id_token_based(request, request_args, extra_args, **kwargs)

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -621,7 +621,7 @@ class TestClient(object):
             ],
         )
 
-    def test_construct_EndSessionRequest(self):
+    def test_construct_EndSessionRequest_kwargs_state(self):
         self.client.grant["foo"] = Grant()
         self.client.grant["foo"].grant_expiration_time = time.time() + 60
         self.client.grant["foo"].code = "access_code"
@@ -637,16 +637,38 @@ class TestClient(object):
         esr = self.client.construct_EndSessionRequest(state="foo", request_args=args)
         assert _eq(esr.keys(), ["id_token", "redirect_url"])
 
-        # state both in request_args and kwargs
-        args.update({"state": "req_args_state"})
-        esr = self.client.construct_EndSessionRequest(state="foo", request_args=args)
-        assert _eq(esr.keys(), ["id_token", "state", "redirect_url"])
-        assert esr["state"] == "req_args_state"
+    def test_construct_EndSessionRequest_reqargs_state(self):
+        self.client.grant["foo"] = Grant()
+        self.client.grant["foo"].grant_expiration_time = time.time() + 60
+        self.client.grant["foo"].code = "access_code"
+
+        resp = AccessTokenResponse(
+            id_token="id_id_id_id", access_token="access", scope=["openid"]
+        )
+
+        self.client.grant["foo"].tokens.append(Token(resp))
 
         # state only in request_args
         args = {"redirect_url": "http://example.com/end", "state": "foo"}
         esr = self.client.construct_EndSessionRequest(request_args=args)
         assert _eq(esr.keys(), ["id_token", "state", "redirect_url"])
+
+    def test_construct_EndSessionRequest_kwargs_and_reqargs_state(self):
+        self.client.grant["foo"] = Grant()
+        self.client.grant["foo"].grant_expiration_time = time.time() + 60
+        self.client.grant["foo"].code = "access_code"
+
+        resp = AccessTokenResponse(
+            id_token="id_id_id_id", access_token="access", scope=["openid"]
+        )
+
+        self.client.grant["foo"].tokens.append(Token(resp))
+
+        # state both in request_args and kwargs
+        args = {"redirect_url": "http://example.com/end", "state": "req_args_state"}
+        esr = self.client.construct_EndSessionRequest(state="foo", request_args=args)
+        assert _eq(esr.keys(), ["id_token", "state", "redirect_url"])
+        assert esr["state"] == "req_args_state"
 
     def test_construct_OpenIDRequest(self):
         self.client.scope = ["openid", "profile"]

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -632,8 +632,20 @@ class TestClient(object):
 
         self.client.grant["foo"].tokens.append(Token(resp))
 
+        # state only in kwargs
         args = {"redirect_url": "http://example.com/end"}
         esr = self.client.construct_EndSessionRequest(state="foo", request_args=args)
+        assert _eq(esr.keys(), ["id_token", "redirect_url"])
+
+        # state both in request_args and kwargs
+        args.update({"state": "req_args_state"})
+        esr = self.client.construct_EndSessionRequest(state="foo", request_args=args)
+        assert _eq(esr.keys(), ["id_token", "state", "redirect_url"])
+        assert esr["state"] == "req_args_state"
+
+        # state only in request_args
+        args = {"redirect_url": "http://example.com/end", "state": "foo"}
+        esr = self.client.construct_EndSessionRequest(request_args=args)
         assert _eq(esr.keys(), ["id_token", "state", "redirect_url"])
 
     def test_construct_OpenIDRequest(self):


### PR DESCRIPTION
'state' in kwargs is used as a key to access information in the RP.
'state' in request_args is just a request argument.
They are not necessarily the same.

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---
