### PR TITLE
Allow no post_logout_redirect_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on the [KeepAChangeLog] project.
 
 ## Unreleased
 
+### Fixed
+- [#711] Deal with no post_logout_redirect_uri
+
+[#711]: https://github.com/OpenIDC/pyoidc/pull/711
+
 ## 1.1.1 [2019-11-04]
 
 ### Fixed


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [x] Changes are covered by tests.
---
If no post_logout_redirect_uris are registered and no post_logut_redirect_uri appears in the
request, the user will be redirect to a post logout uri defined by the OP.