### PR TITLE
Set Content-Type for backchannel logout POSTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ The format is based on the [KeepAChangeLog] project.
 
 ### Fixed
 - [#711] Deal with no post_logout_redirect_uri
+- [#712] Set Content-Type on BackChannel logout POST.
 
 [#711]: https://github.com/OpenIDC/pyoidc/pull/711
+[#712]: https://github.com/OpenIDC/pyoidc/pull/712
 
 ## 1.1.1 [2019-11-04]
 

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -2282,13 +2282,17 @@ class Provider(AProvider):
         # take care of Back channel logout first
         if logout_spec["back_channel"]:
             failed = []
+            headers = {"Content-Type": "application/x-www-form-urlencoded"}
             for _cid, spec in logout_spec["back_channel"].items():
                 _url, sjwt = spec
                 logger.info("logging out from {} at {}".format(_cid, _url))
 
                 try:
                     res = self.httpc.http_request(
-                        _url, "POST", data="logout_token={}".format(sjwt)
+                        _url,
+                        "POST",
+                        data="logout_token={}".format(sjwt),
+                        headers=headers,
                     )
                 except Exception as err:
                     # Can't be more specific because I don't know which http client are used


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---

According to spec the POST body uses the application/x-www-form-urlencoded encoding.