### PR TITLE
Missing OP metadata parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ The format is based on the [KeepAChangeLog] project.
 ### Fixed
 - [#711] Deal with no post_logout_redirect_uri
 - [#712] Set Content-Type on BackChannel logout POST.
+- [#717] Missing OP logout metadata.
 
 [#711]: https://github.com/OpenIDC/pyoidc/pull/711
 [#712]: https://github.com/OpenIDC/pyoidc/pull/712
+[#712]: https://github.com/OpenIDC/pyoidc/pull/717
 
 ## 1.1.1 [2019-11-04]
 

--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -887,6 +887,10 @@ class ProviderConfigurationResponse(Message):
         "op_tos_uri": SINGLE_OPTIONAL_STRING,
         "check_session_iframe": SINGLE_OPTIONAL_STRING,
         "end_session_endpoint": SINGLE_OPTIONAL_STRING,
+        "frontchannel_logout_supported": SINGLE_OPTIONAL_BOOLEAN,
+        "frontchannel_logout_session_supported": SINGLE_OPTIONAL_BOOLEAN,
+        "backchannel_logout_supported": SINGLE_OPTIONAL_BOOLEAN,
+        "backchannel_logout_session_supported": SINGLE_OPTIONAL_BOOLEAN,
     }
     c_default = {
         "version": "3.0",
@@ -896,6 +900,10 @@ class ProviderConfigurationResponse(Message):
         "request_uri_parameter_supported": True,
         "require_request_uri_registration": False,
         "grant_types_supported": ["authorization_code", "implicit"],
+        "frontchannel_logout_supported": False,
+        "frontchannel_logout_session_supported": False,
+        "backchannel_logout_supported": False,
+        "backchannel_logout_session_supported": False,
     }
 
     def verify(self, **kwargs):

--- a/tests/test_oic_message.py
+++ b/tests/test_oic_message.py
@@ -332,9 +332,13 @@ class TestProviderConfigurationResponse(object):
                 "request_parameter_supported",
                 "request_uri_parameter_supported",
                 "require_request_uri_registration",
+                "frontchannel_logout_supported",
+                "frontchannel_logout_session_supported",
+                "backchannel_logout_supported",
+                "backchannel_logout_session_supported",
             ]
         )
-        assert sorted(rk) == sorted(list(pcr.keys()))
+        assert set(rk) == set(pcr.keys())
 
     @pytest.mark.parametrize(
         "required_param",


### PR DESCRIPTION
- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [x] Changes are covered by tests.
---

The Front-Channel and Back-Channel specs say that frontchannel_logout_session_supported and backchannel_logout_session_supported SHOULD be registered but that if they're not present, their default values are false. 