### PR TITLE
Allow OpenID Client registration with JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on the [KeepAChangeLog] project.
 
 ## Unreleased
 
+### Added
+- [#719] Add support for JWT registration tokens
+
 ### Fixed
 - [#711] Deal with no post_logout_redirect_uri
 - [#712] Set Content-Type on BackChannel logout POST.
@@ -14,7 +17,8 @@ The format is based on the [KeepAChangeLog] project.
 
 [#711]: https://github.com/OpenIDC/pyoidc/pull/711
 [#712]: https://github.com/OpenIDC/pyoidc/pull/712
-[#712]: https://github.com/OpenIDC/pyoidc/pull/717
+[#717]: https://github.com/OpenIDC/pyoidc/pull/717
+[#719]: https://github.com/OpenIDC/pyoidc/pull/719
 
 ## 1.1.1 [2019-11-04]
 

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -18,6 +18,8 @@ from urllib.parse import urlparse
 from jwkest import as_bytes
 from jwkest import jwe
 from jwkest import jws
+from jwkest import jwt
+from jwkest import BadSyntax
 from jwkest.jwe import JWE
 from requests import ConnectionError
 
@@ -1346,9 +1348,16 @@ class Client(oauth2.Client):
 
         headers = {"content-type": "application/json"}
         if registration_token is not None:
-            headers["Authorization"] = (
-                "Bearer " + b64encode(registration_token.encode()).decode()
-            )
+            try:
+                token = jwt.JWT()
+                token.unpack(registration_token)
+            except BadSyntax:
+                # no JWT
+                registration_token = b64encode(registration_token.encode()).decode()
+            finally:
+                headers["Authorization"] = (
+                    "Bearer " + registration_token
+                )
 
         rsp = self.http_request(url, "POST", data=req.to_json(), headers=headers)
 

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -15,11 +15,11 @@ from typing import cast  # noqa - Used for MyPy
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
+from jwkest import BadSyntax
 from jwkest import as_bytes
 from jwkest import jwe
 from jwkest import jws
 from jwkest import jwt
-from jwkest import BadSyntax
 from jwkest.jwe import JWE
 from requests import ConnectionError
 
@@ -1355,9 +1355,7 @@ class Client(oauth2.Client):
                 # no JWT
                 registration_token = b64encode(registration_token.encode()).decode()
             finally:
-                headers["Authorization"] = (
-                    "Bearer " + registration_token
-                )
+                headers["Authorization"] = "Bearer " + registration_token
 
         rsp = self.http_request(url, "POST", data=req.to_json(), headers=headers)
 

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -791,6 +791,35 @@ class TestOICConsumer:
             header = rsps.calls[0].request.headers["Authorization"]
             assert header == "Bearer aW5pdGlhbF9yZWdpc3RyYXRpb25fdG9rZW4="
 
+    def test_client_register_token_b64(self):
+        c = Consumer(None, None)
+
+        c.redirect_uris = ["https://example.com/authz"]
+
+        client_info = {
+            "client_id": "clientid",
+            "redirect_uris": ["https://example.com/authz"],
+        }
+        registration_token = ("eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6IC"
+        "JlYjc1N2M3Yy00MWRlLTRmZDYtOTkwNy1hNGFiMDY1ZjEzMmEifQ.eyJqdGkiOiI2ZWY0MDZi"
+        "MC02YzA3LTQ0NzctOWU1YS1hY2FiZjNiMWNiMjgiLCJleHAiOjAsIm5iZiI6MCwiaWF0Ijox"
+        "NTczNzMxNjg5LCJpc3MiOiJodHRwczovL29wZW5pZC1wcm92aWRlci5leGFtcGxlLmNvbS9h"
+        "dXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJodHRwczovL29wZW5pZC1wcm92aWRlci5leGFt"
+        "cGxlLmNvbS9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJ0eXAiOiJJbml0aWFsQWNjZXNzVG9rZW4i"
+        "fQ.0XTlit_JcxPZeIy8A4BzrHn1NvegVP7ws8KI0ySFex8")
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.POST,
+                "https://provider.example.com/registration/",
+                json=client_info,
+            )
+            c.register(
+                "https://provider.example.com/registration/",
+                registration_token=registration_token,
+            )
+            header = rsps.calls[0].request.headers["Authorization"]
+            assert header == "Bearer " + registration_token
+
     def _faulty_id_token(self):
         idval = {
             "nonce": "KUEYfRM2VzKDaaKD",

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -800,13 +800,15 @@ class TestOICConsumer:
             "client_id": "clientid",
             "redirect_uris": ["https://example.com/authz"],
         }
-        registration_token = ("eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6IC"
-        "JlYjc1N2M3Yy00MWRlLTRmZDYtOTkwNy1hNGFiMDY1ZjEzMmEifQ.eyJqdGkiOiI2ZWY0MDZi"
-        "MC02YzA3LTQ0NzctOWU1YS1hY2FiZjNiMWNiMjgiLCJleHAiOjAsIm5iZiI6MCwiaWF0Ijox"
-        "NTczNzMxNjg5LCJpc3MiOiJodHRwczovL29wZW5pZC1wcm92aWRlci5leGFtcGxlLmNvbS9h"
-        "dXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJodHRwczovL29wZW5pZC1wcm92aWRlci5leGFt"
-        "cGxlLmNvbS9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJ0eXAiOiJJbml0aWFsQWNjZXNzVG9rZW4i"
-        "fQ.0XTlit_JcxPZeIy8A4BzrHn1NvegVP7ws8KI0ySFex8")
+        registration_token = (
+            "eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6IC"
+            "JlYjc1N2M3Yy00MWRlLTRmZDYtOTkwNy1hNGFiMDY1ZjEzMmEifQ.eyJqdGkiOiI2ZWY0MDZi"
+            "MC02YzA3LTQ0NzctOWU1YS1hY2FiZjNiMWNiMjgiLCJleHAiOjAsIm5iZiI6MCwiaWF0Ijox"
+            "NTczNzMxNjg5LCJpc3MiOiJodHRwczovL29wZW5pZC1wcm92aWRlci5leGFtcGxlLmNvbS9h"
+            "dXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJodHRwczovL29wZW5pZC1wcm92aWRlci5leGFt"
+            "cGxlLmNvbS9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJ0eXAiOiJJbml0aWFsQWNjZXNzVG9rZW4i"
+            "fQ.0XTlit_JcxPZeIy8A4BzrHn1NvegVP7ws8KI0ySFex8"
+        )
         with responses.RequestsMock() as rsps:
             rsps.add(
                 rsps.POST,


### PR DESCRIPTION
When register an OpenID Client,
registration tokens that are valid JWTs are now passed through to the
OpenID Provider. Every other string is still base64 encoded.
This closes #718 

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
Don't know if the previous two are applicable.
- [x] New code is annotated.
- [x] Changes are covered by tests.
---
