### PR TITLE
Err code 501 504

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -2298,6 +2298,11 @@ class Provider(AProvider):
 
                 if res.status_code < 300:
                     logger.info("Logged out from {}".format(_cid))
+                elif res.status_code in [501, 504]:
+                    logger.info(
+                        "Received a %s error, which is OK according to the spec",
+                        res.status_code,
+                    )
                 else:
                     _errstr = "failed to logout from {}".format(_cid)
                     if self.events:

--- a/tests/test_oic_provider_logout.py
+++ b/tests/test_oic_provider_logout.py
@@ -1085,3 +1085,53 @@ class TestProvider(object):
         assert set(res.keys()) == {"back_channel", "front_channel"}
         assert set(res["back_channel"].keys()) == {"number5"}
         assert set(res["front_channel"].keys()) == {"number5"}
+
+    def test_do_bc_logout_501_response(self):
+        self._code_auth()
+
+        # client0
+        self.provider.cdb["number5"][
+            "backchannel_logout_uri"
+        ] = "https://example.com/bc_logout"
+        self.provider.cdb["number5"]["client_id"] = "number5"
+
+        try:
+            del self.provider.cdb["number5"]["frontchannel_logout_uri"]
+        except KeyError:
+            pass
+
+        # Get a session ID, anyone will do.
+        # I know the session backend DB is a DictSessionBackend so I can use that
+        _sid = list(self.provider.sdb._db.storage.keys())[0]
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.POST, "https://example.com/bc_logout", status=501)
+            res = self.provider.do_verified_logout(_sid, "number5", alla=True)
+
+        # Accepted the 501
+        assert set(res.keys()) == {'cookie'}
+
+    def test_do_bc_logout_504_response(self):
+        self._code_auth()
+
+        # client0
+        self.provider.cdb["number5"][
+            "backchannel_logout_uri"
+        ] = "https://example.com/bc_logout"
+        self.provider.cdb["number5"]["client_id"] = "number5"
+
+        try:
+            del self.provider.cdb["number5"]["frontchannel_logout_uri"]
+        except KeyError:
+            pass
+
+        # Get a session ID, anyone will do.
+        # I know the session backend DB is a DictSessionBackend so I can use that
+        _sid = list(self.provider.sdb._db.storage.keys())[0]
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(rsps.POST, "https://example.com/bc_logout", status=504)
+            res = self.provider.do_verified_logout(_sid, "number5", alla=True)
+
+        # Accepted the 504
+        assert set(res.keys()) == {'cookie'}

--- a/tests/test_oic_provider_logout.py
+++ b/tests/test_oic_provider_logout.py
@@ -1109,7 +1109,7 @@ class TestProvider(object):
             res = self.provider.do_verified_logout(_sid, "number5", alla=True)
 
         # Accepted the 501
-        assert set(res.keys()) == {'cookie'}
+        assert set(res.keys()) == {"cookie"}
 
     def test_do_bc_logout_504_response(self):
         self._code_auth()
@@ -1134,4 +1134,4 @@ class TestProvider(object):
             res = self.provider.do_verified_logout(_sid, "number5", alla=True)
 
         # Accepted the 504
-        assert set(res.keys()) == {'cookie'}
+        assert set(res.keys()) == {"cookie"}


### PR DESCRIPTION
- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---

According to the backchannel draft a backchannel logout request should accept error codes 501 and 504 beside the normally accepted 200.
https://openid.net/specs/openid-connect-backchannel-1_0.html#BCResponse