### PR TITLE
Handle HTTP 405 (method not allowed error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on the [KeepAChangeLog] project.
 
 ## Unreleased
 
+### Added
+- [#739] Better error message for providers which return HTTP Error 405 on userinfo
+
+[#739] https://github.com/OpenIDC/pyoidc/pull/739/
+
 ## 1.2.0 [2020-02-05]
 
 ### Fixed

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -28,6 +28,7 @@ from oic import rndstr
 from oic.exception import AccessDenied
 from oic.exception import AuthnToOld
 from oic.exception import AuthzError
+from oic.exception import CommunicationError
 from oic.exception import MissingParameter
 from oic.exception import ParameterError
 from oic.exception import PyoidcError
@@ -938,6 +939,12 @@ class Client(oauth2.Client):
                 )
         elif resp.status_code == 500:
             raise PyoidcError("ERROR: Something went wrong: %s" % resp.text)
+        elif resp.status_code == 405:
+            # Method not allowed error
+            allowed_methods = [x.strip() for x in resp.headers["allow"].split(",")]
+            raise CommunicationError(
+                "Server responded with HTTP Error Code 405", "", allowed_methods
+            )
         elif 400 <= resp.status_code < 500:
             # the response text might be a OIDC message
             try:


### PR DESCRIPTION
Hi,

I wrote a client with that supports multiple providers. One of the providers restricts the HTTP Method
to GET. I don't want to restrict every provider to only use get, maybe the next will only support POST.
Since clients must return allowed methods, I looked into the http header and retry the userinfo request. If this is wanted behaviour, I would write test code for this.
Else, I would at least raise a different exception, since the resp.text is in my case empty and the
status code is not returned.

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [x] Changes are covered by tests.
---
