### PR TITLE
Fix: SINGLE_OPTIONAL_BOOLEAN allow to serialise/deserialise as JSON

### DIFF
--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -98,7 +98,7 @@ def json_rest(val, sformat=None, lev=0):
 
 
 # value type, required, serializer, deserializer, null value allowed
-SINGLE_OPTIONAL_BOOLEAN = ParamDefinition(bool, False, None, None, False)
+SINGLE_OPTIONAL_BOOLEAN = ParamDefinition(bool, False, json_ser, json_deser, False)
 SINGLE_OPTIONAL_JSON_WN = ParamDefinition(dict, False, json_ser, json_deser, True)
 SINGLE_OPTIONAL_JSON_CONV = ParamDefinition(dict, False, json_conv, json_rest, True)
 SINGLE_REQUIRED_INT = ParamDefinition(int, True, None, None, False)


### PR DESCRIPTION
Do the parsing of boolean objects in case it's set to boolean as json string

Prevents error as such:
```
  File "/home/rebelmouse/env/rebelmouse/local/lib/python2.7/site-packages/oic/oic/message.py", line 339, in verify
    self["id_token"] = verify_id_token(self, **kwargs)
  File "/home/rebelmouse/env/rebelmouse/local/lib/python2.7/site-packages/oic/oic/message.py", line 296, in verify_id_token
    idt = IdToken().from_jwt(_jws, **args)
  File "/home/rebelmouse/env/rebelmouse/local/lib/python2.7/site-packages/oic/oauth2/message.py", line 686, in from_jwt
    return self.from_dict(jso)
  File "/home/rebelmouse/env/rebelmouse/local/lib/python2.7/site-packages/oic/oauth2/message.py", line 359, in from_dict
    self._add_value(skey, vtyp, key, val, _deser, null_allowed)
  File "/home/rebelmouse/env/rebelmouse/local/lib/python2.7/site-packages/oic/oauth2/message.py", line 395, in _add_value
    raise ValueError('"{}", wrong type of value for "{}"'.format(val, skey))
ValueError: "true", wrong type of value for "email_verified"
```
---
