### PR TITLE
Remove deprecation warning: import Mapping from collections.abc

### DIFF
--- a/src/oic/utils/sanitize.py
+++ b/src/oic/utils/sanitize.py
@@ -1,5 +1,5 @@
 import re
-from collections import Mapping
+from collections.abc import Mapping
 from textwrap import dedent
 
 SENSITIVE_THINGS = {


### PR DESCRIPTION
Currently when using this library I get the warning
```
path\to\site-packages\oic\utils\sanitize.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping
```

Since the min python version is 3.5 this can be safely changed