### PR TITLE
Clear quality output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ ignore_errors = True
 deps = twine
 extras = quality
 commands =
-    isort --recursive --diff --check-only src/ tests/
+    isort --diff --check-only src/ tests/
     pylama src/ tests/
     pydocstyle src
     mypy --config-file mypy.ini src/ tests/


### PR DESCRIPTION
- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---
`isort` in quality build uses deprecated option. Remove it from usage.

I wasn't able to remove the warning about distutils, it will go away in newer versions of python (doesn't show up in 3.8 for me) but I am not sure if we want to switch the quality to newer python or not.