### PR TITLE
Remove deprecated urllib.parse.splitquery calls

### DIFF
--- a/src/oic/extension/provider.py
+++ b/src/oic/extension/provider.py
@@ -3,7 +3,7 @@ import logging
 import socket
 from typing import Dict
 from urllib.parse import parse_qs
-from urllib.parse import splitquery  # type: ignore
+from urllib.parse import urlparse
 
 from jwkest import b64e
 
@@ -213,7 +213,9 @@ class Provider(provider.Provider):
     def _uris_to_tuples(uris):
         tup = []
         for uri in uris:
-            base, query = splitquery(uri)
+            part = urlparse(uri)
+            query = part.query
+            base = part._replace(query="").geturl()
             if query:
                 tup.append((base, query))
             else:

--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -11,7 +11,6 @@ from typing import List
 from typing import Optional
 from typing import Union
 from urllib.parse import parse_qs
-from urllib.parse import splitquery  # type: ignore
 from urllib.parse import unquote
 from urllib.parse import urljoin
 from urllib.parse import urlparse
@@ -322,9 +321,8 @@ class Provider(object):
             if part.fragment:
                 raise URIError("Contains fragment")
 
-            (_base, _query) = splitquery(_redirect_uri)
-            if _query:
-                _query = parse_qs(_query)
+            _query = parse_qs(part.query) if part.query else None
+            _base = part._replace(query="").geturl()
 
             match = False
             for regbase, rquery in self.cdb[str(areq["client_id"])]["redirect_uris"]:

--- a/src/oic/utils/client_management.py
+++ b/src/oic/utils/client_management.py
@@ -9,7 +9,6 @@ from builtins import input
 from typing import Any
 from typing import List
 from urllib.parse import parse_qs
-from urllib.parse import splitquery  # type: ignore
 from urllib.parse import urlparse
 
 from oic import rndstr
@@ -33,13 +32,15 @@ def unpack_redirect_uri(redirect_uris):
 def pack_redirect_uri(redirect_uris):
     ruri = []
     for uri in redirect_uris:
-        if urlparse(uri).fragment:
+        parts = urlparse(uri)
+        if parts.fragment:
             print("Faulty redirect uri, contains fragment", file=sys.stderr)
-        base, query = splitquery(uri)
+        query = parts.query
+        base = parts._replace(query="").geturl()
         if query:
             ruri.append([base, parse_qs(query)])
         else:
-            ruri.append([base, query])
+            ruri.append([base, None])
 
     return ruri
 

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -590,7 +590,7 @@ class TestClient(object):
             )
 
             resp = self.client.do_access_token_request(request_args=request_args)
-            request = parse_qs(rsps.calls[0].request.body)
+            request = parse_qs(str(rsps.calls[0].request.body))
             assert request["assertion"][0] == "saml assertion"
             assert (
                 request["grant_type"][0]

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -398,7 +398,7 @@ class TestClient(object):
                 body=IDTOKEN.to_json(),
             )
             resp = self.client.do_check_session_request(request_args=args)
-            parsed = parse_qs(urlparse(rsps.calls[0].request.url).query)
+            parsed = parse_qs(str(urlparse(rsps.calls[0].request.url).query))
             assert parsed["id_token"] is not None
 
         assert isinstance(resp, IdToken)

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -998,7 +998,7 @@ class TestOICConsumer:
         with responses.RequestsMock() as rsps:
             rsps.add(responses.POST, "https://example.com/register/", json=reg_resp)
             c.register("https://example.com/register/")
-            assert json.loads(rsps.calls[0].request.body) == {
+            assert json.loads(str(rsps.calls[0].request.body)) == {
                 "application_type": "web",
                 "response_types": ["code"],
                 "redirect_uris": ["https://example.com/authz"],


### PR DESCRIPTION
Fix the deprecated splitquery calls.

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---
