### PR TITLE
doc: fix Docker URL

### DIFF
--- a/doc/examples/docker.rst
+++ b/doc/examples/docker.rst
@@ -6,7 +6,7 @@ So, you just want to see how it works?
 In order to get started, you'll need to install Docker_. Once installed, please
 run the `runOpRp.sh`_ script in the root of the repository.
 
-.. _Docker: https://www.docker.com://www.docker.com/
+.. _Docker: https://docs.docker.com/get-docker/
 .. _runOpRp.sh: https://github.com/OpenIDC/pyoidc/blob/master/runOpRp.sh
 
 This will set up the following:


### PR DESCRIPTION
Replace the broken double-pasted URL with a working one pointing to the
downloads page for Docker CE.
