### PR TITLE
fix: use logger instance rather than raw logging

### DIFF
--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -190,7 +190,7 @@ class KeyBundle(object):
             args["headers"] = {"If-None-Match": self.etag}
 
         try:
-            logging.debug("KeyBundle fetch keys from: %s", self.source)
+            logger.debug("KeyBundle fetch keys from: %s", self.source)
             r = requests.get(self.source, **args)
         except Exception as err:
             logger.error(err)


### PR DESCRIPTION
- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
  - No changes relevant to users
- [ ] The documentation has been updated, if necessary.
  - No documentation update needed
- [ ] New code is annotated.
  - Not relevant
- [ ] Changes are covered by tests.
  - Not relevant
---

Hey,

I replace a debug log line using directly `logging` by the use of the `logger` instance.
Otherwise, while configuring `oic` logging to level `INFO` in my application, I still get a `DEBUG` root login `KeyBundle fetch keys from: <url>`
I can't figure out any reason to use `logging` here.