### PR TITLE
pass through `**kwargs` to ensure additional args like `skew` can be set

### DIFF
--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -955,7 +955,7 @@ class Client(PBase):
             http_args.update(ht_args)
 
         response = self.request_and_return(
-            url, response_cls, method, body, body_type, state=state, http_args=http_args
+            url, response_cls, method, body, body_type, state=state, http_args=http_args, **kwargs
         )
         if token.replaced:
             grant = self.get_grant(state)

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -955,7 +955,14 @@ class Client(PBase):
             http_args.update(ht_args)
 
         response = self.request_and_return(
-            url, response_cls, method, body, body_type, state=state, http_args=http_args, **kwargs
+            url,
+            response_cls,
+            method,
+            body,
+            body_type,
+            state=state,
+            http_args=http_args,
+            **kwargs,
         )
         if token.replaced:
             grant = self.get_grant(state)


### PR DESCRIPTION
fixes #785