### PR TITLE
Add mention of Python 3.9 in the trove classifier list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries :: Python Modules"],
     python_requires='~=3.5',
     extras_require={


### PR DESCRIPTION
Just adding 3.9 to the supported list.

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---
