### PR TITLE
Remove Travis Build Banner

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://api.travis-ci.org/OpenIDC/pyoidc.png?branch=master
-    :target: https://travis-ci.org/OpenIDC/pyoidc
-
 .. image:: https://ci.appveyor.com/api/projects/status/5g3ucux767mef3f4/branch/master?svg=true
     :target: https://ci.appveyor.com/project/tpazderka/pyoidc/branch/master
 


### PR DESCRIPTION
travis-ci.org is officially dead since 15 of June 2021, so this is now useless.

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---
