### PR TITLE
Add compatibility with Apple ID oauth messages

### DIFF
--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -383,9 +383,14 @@ class Message(MutableMapping):
                     else:
                         return
                 elif vtyp is bool:
-                    raise ParameterError(
-                        '"{}", wrong type of value for "{}"'.format(val, skey)
-                    )
+                    if val == "true":
+                        self._dict[skey] = True
+                    elif val == "false":
+                        self._dict[skey] = False
+                    else:
+                        raise ParameterError(
+                            '"{}", wrong type of value for "{}"'.format(val, skey)
+                        )
 
                 if isinstance(val, str):
                     self._dict[skey] = val


### PR DESCRIPTION
- [X] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---
Apple ID returns a boolean as text vs raw boolean. This was detected using SATOSA (https://github.com/IdentityPython/SATOSA) that depends on this library. When is configured to use Apple ID as backend, then the response of apple rise an exception:
```
[2021-07-19 18:11:26,907] [ERROR] [satosa.proxy_server.__call__] Unknown error
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/SATOSA-7.0.1-py3.8.egg/satosa/base.py", line 240, in run
    resp = self._run_bound_endpoint(context, spec)
  File "/usr/local/lib/python3.8/site-packages/SATOSA-7.0.1-py3.8.egg/satosa/base.py", line 180, in _run_bound_endpoint
    return spec(context)
  File "/usr/local/lib/python3.8/site-packages/SATOSA-7.0.1-py3.8.egg/satosa/backends/apple.py", line 207, in response_endpoint
    access_token, id_token_claims = self._get_tokens(authn_resp, context)
  File "/usr/local/lib/python3.8/site-packages/SATOSA-7.0.1-py3.8.egg/satosa/backends/apple.py", line 124, in _get_tokens
    token_resp = self.client.do_access_token_request(scope="openid", state=authn_response["state"],
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oic/__init__.py", line 703, in do_access_token_request
    atr = super().do_access_token_request(
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oauth2/__init__.py", line 919, in do_access_token_request
    return self.request_and_return(
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oauth2/__init__.py", line 812, in request_and_return
    return self.parse_request_response(resp, response, body_type, state, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oauth2/__init__.py", line 753, in parse_request_response
    return self.parse_response(
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oauth2/__init__.py", line 675, in parse_response
    verf = resp.verify(**kwargs)
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oic/message.py", line 356, in verify
    self["id_token"] = verify_id_token(self, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oic/message.py", line 310, in verify_id_token
    idt = IdToken().from_jwt(_jws, **args)
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oauth2/message.py", line 692, in from_jwt
    return self.from_dict(jso)
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oauth2/message.py", line 344, in from_dict
    self._add_value(
  File "/usr/local/lib/python3.8/site-packages/oic-1.3.0-py3.8.egg/oic/oauth2/message.py", line 386, in _add_value
    raise ParameterError(
oic.oauth2.message.ParameterError: "true", wrong type of value for "email_verified"
```
where you can see the `"true"` vs the expected `true`.