### PR TITLE
docs: Fix a few typos

### DIFF
--- a/oidc_example/op2/static/bootstrap/css/angular.js
+++ b/oidc_example/op2/static/bootstrap/css/angular.js
@@ -7466,7 +7466,7 @@ function $HttpProvider() {
         execHeaders(defHeaders);
         execHeaders(reqHeaders);
 
-        // using for-in instead of forEach to avoid unecessary iteration after header has been found
+        // using for-in instead of forEach to avoid unnecessary iteration after header has been found
         defaultHeadersIteration:
         for (defHeaderName in defHeaders) {
           lowercaseDefHeaderName = lowercase(defHeaderName);
@@ -9511,7 +9511,7 @@ Parser.prototype = {
   parse: function (text, json) {
     this.text = text;
 
-    //TODO(i): strip all the obsolte json stuff from this file
+    //TODO(i): strip all the obsolete json stuff from this file
     this.json = json;
 
     this.tokens = this.lexer.lex(text);
@@ -12426,7 +12426,7 @@ function $SceDelegateProvider() {
  * |---------------------|----------------|
  * | `$sce.HTML`         | For HTML that's safe to source into the application.  The {@link ng.directive:ngBindHtml ngBindHtml} directive uses this context for bindings. |
  * | `$sce.CSS`          | For CSS that's safe to source into the application.  Currently unused.  Feel free to use it in your own directives. |
- * | `$sce.URL`          | For URLs that are safe to follow as links.  Currently unused (`<a href=` and `<img src=` sanitize their urls and don't consititute an SCE context. |
+ * | `$sce.URL`          | For URLs that are safe to follow as links.  Currently unused (`<a href=` and `<img src=` sanitize their urls and don't constitute an SCE context. |
  * | `$sce.RESOURCE_URL` | For URLs that are not only safe to follow as links, but whose contens are also safe to include in your application.  Examples include `ng-include`, `src` / `ngSrc` bindings for tags other than `IMG` (e.g. `IFRAME`, `OBJECT`, etc.)  <br><br>Note that `$sce.RESOURCE_URL` makes a stronger statement about the URL than `$sce.URL` does and therefore contexts requiring values trusted for `$sce.RESOURCE_URL` can be used anywhere that values trusted for `$sce.URL` are required. |
  * | `$sce.JS`           | For JavaScript that is safe to execute in your application's context.  Currently unused.  Feel free to use it in your own directives. |
  *
@@ -16743,7 +16743,7 @@ var ngValueDirective = function() {
  * Typically, you don't use `ngBind` directly, but instead you use the double curly markup like
  * `{{ expression }}` which is similar but less verbose.
  *
- * It is preferrable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
+ * It is preferable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
  * displayed by the browser in its raw state before Angular compiles it. Since `ngBind` is an
  * element attribute, it makes the bindings invisible to the user while the page is loading.
  *

--- a/oidc_example/op3/static/bootstrap/css/angular.js
+++ b/oidc_example/op3/static/bootstrap/css/angular.js
@@ -7466,7 +7466,7 @@ function $HttpProvider() {
         execHeaders(defHeaders);
         execHeaders(reqHeaders);
 
-        // using for-in instead of forEach to avoid unecessary iteration after header has been found
+        // using for-in instead of forEach to avoid unnecessary iteration after header has been found
         defaultHeadersIteration:
         for (defHeaderName in defHeaders) {
           lowercaseDefHeaderName = lowercase(defHeaderName);
@@ -9511,7 +9511,7 @@ Parser.prototype = {
   parse: function (text, json) {
     this.text = text;
 
-    //TODO(i): strip all the obsolte json stuff from this file
+    //TODO(i): strip all the obsolete json stuff from this file
     this.json = json;
 
     this.tokens = this.lexer.lex(text);
@@ -12426,7 +12426,7 @@ function $SceDelegateProvider() {
  * |---------------------|----------------|
  * | `$sce.HTML`         | For HTML that's safe to source into the application.  The {@link ng.directive:ngBindHtml ngBindHtml} directive uses this context for bindings. |
  * | `$sce.CSS`          | For CSS that's safe to source into the application.  Currently unused.  Feel free to use it in your own directives. |
- * | `$sce.URL`          | For URLs that are safe to follow as links.  Currently unused (`<a href=` and `<img src=` sanitize their urls and don't consititute an SCE context. |
+ * | `$sce.URL`          | For URLs that are safe to follow as links.  Currently unused (`<a href=` and `<img src=` sanitize their urls and don't constitute an SCE context. |
  * | `$sce.RESOURCE_URL` | For URLs that are not only safe to follow as links, but whose contens are also safe to include in your application.  Examples include `ng-include`, `src` / `ngSrc` bindings for tags other than `IMG` (e.g. `IFRAME`, `OBJECT`, etc.)  <br><br>Note that `$sce.RESOURCE_URL` makes a stronger statement about the URL than `$sce.URL` does and therefore contexts requiring values trusted for `$sce.RESOURCE_URL` can be used anywhere that values trusted for `$sce.URL` are required. |
  * | `$sce.JS`           | For JavaScript that is safe to execute in your application's context.  Currently unused.  Feel free to use it in your own directives. |
  *
@@ -16743,7 +16743,7 @@ var ngValueDirective = function() {
  * Typically, you don't use `ngBind` directly, but instead you use the double curly markup like
  * `{{ expression }}` which is similar but less verbose.
  *
- * It is preferrable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
+ * It is preferable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
  * displayed by the browser in its raw state before Angular compiles it. Since `ngBind` is an
  * element attribute, it makes the bindings invisible to the user while the page is loading.
  *

--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -235,7 +235,7 @@ class KeyBundle(object):
         """
         Parse JWKS from the HTTP response.
 
-        Should be overriden by subclasses for adding support of e.g. signed
+        Should be overridden by subclasses for adding support of e.g. signed
         JWKS.
         :param response: HTTP response from the 'jwks_uri' endpoint
         :return: response parsed as JSON

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -384,7 +384,7 @@ def create_session_db(
     """
     Construct SessionDB instance.
 
-    Using this you can create a very basic non persistant
+    Using this you can create a very basic non persistent
     session database that issues opaque DefaultTokens.
 
     :param base_url: Same as base_url parameter of `SessionDB`.

--- a/src/oic/utils/time_util.py
+++ b/src/oic/utils/time_util.py
@@ -286,7 +286,7 @@ def shift_time(dtime, shift):
 
 def str_to_time(timestr, time_format=TIME_FORMAT):
     """
-    Convert string to time accordign to TIME_FORMAT.
+    Convert string to time according to TIME_FORMAT.
 
     :param timestr:
     :param time_format:


### PR DESCRIPTION
There are small typos in:
- oidc_example/op2/static/bootstrap/css/angular.js
- oidc_example/op3/static/bootstrap/css/angular.js
- src/oic/utils/keyio.py
- src/oic/utils/sdb.py
- src/oic/utils/time_util.py

Fixes:
- Should read `unnecessary` rather than `unecessary`.
- Should read `preferable` rather than `preferrable`.
- Should read `obsolete` rather than `obsolte`.
- Should read `constitute` rather than `consititute`.
- Should read `persistent` rather than `persistant`.
- Should read `overridden` rather than `overriden`.
- Should read `according` rather than `accordign`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md