### PR TITLE
Fixes to make the library work correctly, some fixes to the "simple" example and some internal documentation.

### DIFF
--- a/oidc_example/simple_op/src/provider/authn/user_pass.py
+++ b/oidc_example/simple_op/src/provider/authn/user_pass.py
@@ -29,6 +29,11 @@ class UserPass(AuthnModule):
                                         state=json.dumps(kwargs),
                                         **self.kwargs))
 
+    """
+    Checks if the user can be authenticated with the password provided
+
+    :param kwargs: 
+    """
     def verify(self, *args, **kwargs):
         username = kwargs["username"]
         if username in self.user_db and self.user_db[username] == kwargs[

--- a/oidc_example/simple_op/src/provider/server/server.py
+++ b/oidc_example/simple_op/src/provider/server/server.py
@@ -107,17 +107,24 @@ def resp2flask(resp):
     return resp.message, resp.status, resp.headers
 
 
+"""
+Creates an AuthnBroker with the authentication methods set in settings.yaml.
+
+:returns an AuthnBroker and the routing.
+"""
 def setup_authentication_methods(authn_config, template_env):
     """Add all authentication methods specified in the configuration."""
     routing = {}
     ac = AuthnBroker()
     for authn_method in authn_config:
 
-        # Create instance of each auth class
+        # Create instance of the appropiate auth class.
         cls = make_cls_from_name(authn_method["class"])
         instance = cls(template_env=template_env, **authn_method["kwargs"])
 
+        # Adds the auth method name to the broker.
         ac.add(authn_method["acr"], instance)
+
         routing[instance.url_endpoint] = VerifierMiddleware(instance)
 
     return ac, routing
@@ -126,6 +133,8 @@ def setup_authentication_methods(authn_config, template_env):
 def setup_endpoints(provider):
     """Setup the OpenID Connect Provider endpoints."""
     app_routing = {}
+
+    # Each provider.***** is a pointer to a function
     endpoints = [
         AuthorizationEndpoint(
             pyoidcMiddleware(provider.authorization_endpoint)),
@@ -207,6 +216,8 @@ def main():
     client_db = {}
     session_db = create_session_db(issuer,
                                    secret=rndstr(32), password=rndstr(32))
+
+    # verify_client is a pointer to that function which is used in the token endpoint.
     provider = Provider(issuer, session_db, client_db, authn_broker,
                         userinfo, AuthzHandling(), verify_client, None)
     provider.baseurl = issuer

--- a/oidc_example/simple_op/src/provider/server/server.py
+++ b/oidc_example/simple_op/src/provider/server/server.py
@@ -95,7 +95,11 @@ def pyoidcMiddleware(func):
     def wrapper(environ, start_response):
         data = get_or_post(environ)
         cookies = environ.get("HTTP_COOKIE", "")
-        resp = func(request=data, cookie=cookies)
+        if(environ.get("REQUEST_URI", "") == "/token"):
+            # This is correct at least for our case which is the authorization code flow.
+            resp = func(request=data, cookie=cookies, authn=environ.get("HTTP_AUTHORIZATION", ""))
+        else:
+            resp = func(request=data, cookie=cookies)
         return resp(environ, start_response)
 
     return wrapper

--- a/oidc_example/simple_op/src/provider/server/server.py
+++ b/oidc_example/simple_op/src/provider/server/server.py
@@ -7,7 +7,6 @@ import os
 from functools import partial
 from functools import wraps
 from urllib import parse as urlparse
-
 import cherrypy
 import yaml
 from cherrypy import wsgiserver
@@ -70,13 +69,16 @@ def VerifierMiddleware(verifier):
 
             url = "{base_url}?{query_string}".format(
                 base_url="/authorization",
-                query_string=kwargs["state"]["query"])
+                query_string=urlparse.urlparse(environ.get("HTTP_REFERER")).query)
             response = SeeOther(url, headers=[(set_cookie, cookie_value)])
             return response(environ, start_response)
+
         else:  # Unsuccessful authentication
             url = "{base_url}?{query_string}".format(
                 base_url="/authorization",
-                query_string=kwargs["state"]["query"])
+                query_string=urlparse.urlparse(environ.get("HTTP_REFERER")).query)
+            response = SeeOther(url, headers=[(set_cookie, cookie_value)])
+            return response(environ, start_response)
             response = SeeOther(url)
             return response(environ, start_response)
 

--- a/oidc_example/simple_op/src/provider/server/server.py
+++ b/oidc_example/simple_op/src/provider/server/server.py
@@ -112,8 +112,11 @@ def setup_authentication_methods(authn_config, template_env):
     routing = {}
     ac = AuthnBroker()
     for authn_method in authn_config:
+
+        # Create instance of each auth class
         cls = make_cls_from_name(authn_method["class"])
         instance = cls(template_env=template_env, **authn_method["kwargs"])
+
         ac.add(authn_method["acr"], instance)
         routing[instance.url_endpoint] = VerifierMiddleware(instance)
 

--- a/oidc_example/simple_rp/src/rp.py
+++ b/oidc_example/simple_rp/src/rp.py
@@ -98,6 +98,8 @@ class RPServer(object):
         ]
         _, keyjar, _ = build_keyjar(keys)
         cherrypy.session["client"] = Client(verify_ssl=self.verify_ssl, keyjar=keyjar)
+        cherrypy.session["client"].token_endpoint = "https://localhost/token" 
+        cherrypy.session["client"].userinfo_endpoint = "https://localhost/userinfo"
 
         # webfinger+registration
         self.rp.register_with_dynamic_provider(cherrypy.session, uid)

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -425,6 +425,8 @@ class Client(PBase):
         else:
             request_args = {}
 
+        request_args.update(kwargs)
+
         if "client_id" not in request_args:
             request_args["client_id"] = self.client_id
         elif not request_args["client_id"]:

--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -298,7 +298,7 @@ def verify_id_token(instance, check_hash=False, **kwargs):
 
     if "keyjar" in kwargs:
         try:
-            if _body["iss"] not in kwargs["keyjar"]:
+            if _body["iss"] not in kwargs["iss"]:
                 raise ValueError("Unknown issuer")
         except KeyError:
             raise MissingRequiredAttribute("iss")

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -255,6 +255,9 @@ class Provider(AProvider):
         logout_path="",
         settings: PyoidcSettings = None,
     ):
+        """
+        :param name the iss, which is the URI of the OP.
+        """
         self.settings = settings or OicProviderSettings()
         if verify_ssl is not None:
             warnings.warn(


### PR DESCRIPTION
# Documentation changes (b9e18b6bcf0fb3d981b68671d856a0f3bb9dd31e and e22e2284bb2af1a8c0ad154f4d2a31c5d9cdac3a)

Added some internal documentation to methods of the "simple" examples and the library.

# Fixes to make the authentication request/response work 

## 0cd29446a83793ba6677c76e95f1ec8ab10a2a35

In the oic.oauth2 construct_Authorization method the request args in kwargs are never added to the request_args of the request and therefore you can't get the client_id, the state, the redirection_uris etc when trying to complete the auth in the VerifierMiddleware of the OP, atleast in the "simple op" example. There are some changes needed for the VerifierMiddleware to work too. In my proposal I use the HTTP_REFERER header to get the query args of the previous request which is the request to get the login static page and it has the arguments we added in the construct_Authorization method which makes it possible to get authenticated correctly.

# Fixes to make the token request/response work and the userinfo request/response work 

## 897a6527de0b41d9a313aa93c8b5affe64640b24

The token endpoint and userinfo endpoint are never added to the Client instance so I added them just after the Client creation. Someone with more knowledge about the library than me can try and add these changes inside the library functions almost certainly. 

## ce469a9832015fdd9b151b1d0aa6686998b8b41c 

When trying to get the access token some method of the library needs to check the authorization header with the Bearer token of the HTTP Basic Auth when using the authorization code flow but this header is ignored when the request is processed using the pyoidcMiddleware so I add this header in each request to the token endpoint and it works now.

## 1e98232734050c3150dcc1041b963c43a024393c

When the issuer of the id token is verified in the library methods the iss is checked against the keyjar which makes no sense and makes the verification fail always. Now it checks it against the known iss.

