### PR TITLE
Included id_token_jwt in token response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 Vagrantfile
 Pipfile
 Pipfile.lock
-venv
 
 # setup.py-related folders and files
 build
@@ -36,7 +35,6 @@ foo.*
 .cache/
 .pytest_cache
 .mypy_cache
-tests/Users
 
 # Dynamically created doc folders
 doc/_build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 Vagrantfile
 Pipfile
 Pipfile.lock
+venv
 
 # setup.py-related folders and files
 build
@@ -35,6 +36,7 @@ foo.*
 .cache/
 .pytest_cache
 .mypy_cache
+tests/Users
 
 # Dynamically created doc folders
 doc/_build

--- a/oidc_example/op2/static/bootstrap/css/angular.js
+++ b/oidc_example/op2/static/bootstrap/css/angular.js
@@ -7466,7 +7466,7 @@ function $HttpProvider() {
         execHeaders(defHeaders);
         execHeaders(reqHeaders);
 
-        // using for-in instead of forEach to avoid unecessary iteration after header has been found
+        // using for-in instead of forEach to avoid unnecessary iteration after header has been found
         defaultHeadersIteration:
         for (defHeaderName in defHeaders) {
           lowercaseDefHeaderName = lowercase(defHeaderName);
@@ -9511,7 +9511,7 @@ Parser.prototype = {
   parse: function (text, json) {
     this.text = text;
 
-    //TODO(i): strip all the obsolte json stuff from this file
+    //TODO(i): strip all the obsolete json stuff from this file
     this.json = json;
 
     this.tokens = this.lexer.lex(text);
@@ -12426,7 +12426,7 @@ function $SceDelegateProvider() {
  * |---------------------|----------------|
  * | `$sce.HTML`         | For HTML that's safe to source into the application.  The {@link ng.directive:ngBindHtml ngBindHtml} directive uses this context for bindings. |
  * | `$sce.CSS`          | For CSS that's safe to source into the application.  Currently unused.  Feel free to use it in your own directives. |
- * | `$sce.URL`          | For URLs that are safe to follow as links.  Currently unused (`<a href=` and `<img src=` sanitize their urls and don't consititute an SCE context. |
+ * | `$sce.URL`          | For URLs that are safe to follow as links.  Currently unused (`<a href=` and `<img src=` sanitize their urls and don't constitute an SCE context. |
  * | `$sce.RESOURCE_URL` | For URLs that are not only safe to follow as links, but whose contens are also safe to include in your application.  Examples include `ng-include`, `src` / `ngSrc` bindings for tags other than `IMG` (e.g. `IFRAME`, `OBJECT`, etc.)  <br><br>Note that `$sce.RESOURCE_URL` makes a stronger statement about the URL than `$sce.URL` does and therefore contexts requiring values trusted for `$sce.RESOURCE_URL` can be used anywhere that values trusted for `$sce.URL` are required. |
  * | `$sce.JS`           | For JavaScript that is safe to execute in your application's context.  Currently unused.  Feel free to use it in your own directives. |
  *
@@ -16743,7 +16743,7 @@ var ngValueDirective = function() {
  * Typically, you don't use `ngBind` directly, but instead you use the double curly markup like
  * `{{ expression }}` which is similar but less verbose.
  *
- * It is preferrable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
+ * It is preferable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
  * displayed by the browser in its raw state before Angular compiles it. Since `ngBind` is an
  * element attribute, it makes the bindings invisible to the user while the page is loading.
  *

--- a/oidc_example/op3/static/bootstrap/css/angular.js
+++ b/oidc_example/op3/static/bootstrap/css/angular.js
@@ -7466,7 +7466,7 @@ function $HttpProvider() {
         execHeaders(defHeaders);
         execHeaders(reqHeaders);
 
-        // using for-in instead of forEach to avoid unecessary iteration after header has been found
+        // using for-in instead of forEach to avoid unnecessary iteration after header has been found
         defaultHeadersIteration:
         for (defHeaderName in defHeaders) {
           lowercaseDefHeaderName = lowercase(defHeaderName);
@@ -9511,7 +9511,7 @@ Parser.prototype = {
   parse: function (text, json) {
     this.text = text;
 
-    //TODO(i): strip all the obsolte json stuff from this file
+    //TODO(i): strip all the obsolete json stuff from this file
     this.json = json;
 
     this.tokens = this.lexer.lex(text);
@@ -12426,7 +12426,7 @@ function $SceDelegateProvider() {
  * |---------------------|----------------|
  * | `$sce.HTML`         | For HTML that's safe to source into the application.  The {@link ng.directive:ngBindHtml ngBindHtml} directive uses this context for bindings. |
  * | `$sce.CSS`          | For CSS that's safe to source into the application.  Currently unused.  Feel free to use it in your own directives. |
- * | `$sce.URL`          | For URLs that are safe to follow as links.  Currently unused (`<a href=` and `<img src=` sanitize their urls and don't consititute an SCE context. |
+ * | `$sce.URL`          | For URLs that are safe to follow as links.  Currently unused (`<a href=` and `<img src=` sanitize their urls and don't constitute an SCE context. |
  * | `$sce.RESOURCE_URL` | For URLs that are not only safe to follow as links, but whose contens are also safe to include in your application.  Examples include `ng-include`, `src` / `ngSrc` bindings for tags other than `IMG` (e.g. `IFRAME`, `OBJECT`, etc.)  <br><br>Note that `$sce.RESOURCE_URL` makes a stronger statement about the URL than `$sce.URL` does and therefore contexts requiring values trusted for `$sce.RESOURCE_URL` can be used anywhere that values trusted for `$sce.URL` are required. |
  * | `$sce.JS`           | For JavaScript that is safe to execute in your application's context.  Currently unused.  Feel free to use it in your own directives. |
  *
@@ -16743,7 +16743,7 @@ var ngValueDirective = function() {
  * Typically, you don't use `ngBind` directly, but instead you use the double curly markup like
  * `{{ expression }}` which is similar but less verbose.
  *
- * It is preferrable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
+ * It is preferable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
  * displayed by the browser in its raw state before Angular compiles it. Since `ngBind` is an
  * element attribute, it makes the bindings invisible to the user while the page is loading.
  *

--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -352,6 +352,10 @@ class AccessTokenResponse(message.AccessTokenResponse):
     def verify(self, **kwargs):
         super().verify(**kwargs)
         if "id_token" in self:
+            # The ID token JWT needs to be passed in the access token response
+            # to be usable as id_token_hint for RP-Initiated Logout. Refer to
+            # https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+            self["id_token_jwt"] = self["id_token"]
             # replace the JWT with the verified IdToken instance
             self["id_token"] = verify_id_token(self, **kwargs)
 

--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -235,7 +235,7 @@ class KeyBundle(object):
         """
         Parse JWKS from the HTTP response.
 
-        Should be overriden by subclasses for adding support of e.g. signed
+        Should be overridden by subclasses for adding support of e.g. signed
         JWKS.
         :param response: HTTP response from the 'jwks_uri' endpoint
         :return: response parsed as JSON

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -384,7 +384,7 @@ def create_session_db(
     """
     Construct SessionDB instance.
 
-    Using this you can create a very basic non persistant
+    Using this you can create a very basic non persistent
     session database that issues opaque DefaultTokens.
 
     :param base_url: Same as base_url parameter of `SessionDB`.

--- a/src/oic/utils/time_util.py
+++ b/src/oic/utils/time_util.py
@@ -286,7 +286,7 @@ def shift_time(dtime, shift):
 
 def str_to_time(timestr, time_format=TIME_FORMAT):
     """
-    Convert string to time accordign to TIME_FORMAT.
+    Convert string to time according to TIME_FORMAT.
 
     :param timestr:
     :param time_format:

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -518,7 +518,15 @@ class TestOICConsumer:
         assert auth is None
         assert isinstance(atr, AccessTokenResponse)
         assert _eq(
-            atr.keys(), ["access_token", "id_token", "id_token_jwt", "token_type", "state", "scope"]
+            atr.keys(),
+            [
+                "access_token",
+                "id_token",
+                "id_token_jwt",
+                "token_type",
+                "state",
+                "scope",
+            ],
         )
         assert isinstance(idt, IdToken)
 
@@ -580,7 +588,15 @@ class TestOICConsumer:
         assert auth is None
         assert isinstance(atr, AccessTokenResponse)
         assert _eq(
-            atr.keys(), ["access_token", "id_token", "id_token_jwt", "token_type", "state", "scope"]
+            atr.keys(),
+            [
+                "access_token",
+                "id_token",
+                "id_token_jwt",
+                "token_type",
+                "state",
+                "scope",
+            ],
         )
         assert isinstance(idt, IdToken)
 

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -518,7 +518,7 @@ class TestOICConsumer:
         assert auth is None
         assert isinstance(atr, AccessTokenResponse)
         assert _eq(
-            atr.keys(), ["access_token", "id_token", "token_type", "state", "scope"]
+            atr.keys(), ["access_token", "id_token", "id_token_jwt", "token_type", "state", "scope"]
         )
         assert isinstance(idt, IdToken)
 
@@ -580,7 +580,7 @@ class TestOICConsumer:
         assert auth is None
         assert isinstance(atr, AccessTokenResponse)
         assert _eq(
-            atr.keys(), ["access_token", "id_token", "token_type", "state", "scope"]
+            atr.keys(), ["access_token", "id_token", "id_token_jwt", "token_type", "state", "scope"]
         )
         assert isinstance(idt, IdToken)
 


### PR DESCRIPTION
The ID token JWT needs to be passed in the access token response to be usable as id_token_hint for RP-Initiated Logout. Refer to [RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) specification.

The existing code replaces JWT with the verified IdToken instance but it should be preserved. I've added `id_token_jwt` which stores signed and serialised ID token.