### PR TITLE
Fixed parsing for zero content length response

### DIFF
--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -747,7 +747,10 @@ class Client(PBase):
             )
 
         if response:
-            if body_type == "txt":
+            if body_type is None:
+                # There is no content-type for zero content length. Return the status code.
+                return reqresp.status_code
+            elif body_type == "txt":
                 # no meaning trying to parse unstructured text
                 return reqresp.text
             return self.parse_response(

--- a/src/oic/oauth2/util.py
+++ b/src/oic/oauth2/util.py
@@ -185,6 +185,8 @@ def verify_header(reqresp, body_type):
     logger.debug("resp.txt: %s" % (sanitize(reqresp.text),))
 
     if body_type == "":
+        if int(reqresp.headers["content-length"]) == 0:
+            return None
         _ctype = reqresp.headers["content-type"]
         if match_to_("application/json", _ctype):
             body_type = "json"

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -5,8 +5,8 @@ from urllib.parse import urlencode
 from urllib.parse import urlparse
 
 import pytest
-import responses
 import requests
+import responses
 
 from oic.oauth2 import Client
 from oic.oauth2 import Grant

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 import pytest
 import responses
+import requests
 
 from oic.oauth2 import Client
 from oic.oauth2 import Grant
@@ -25,6 +26,7 @@ from oic.oauth2.message import ErrorResponse
 from oic.oauth2.message import ExtensionTokenRequest
 from oic.oauth2.message import FormatError
 from oic.oauth2.message import GrantExpired
+from oic.oauth2.message import Message
 from oic.oauth2.message import MessageTuple
 from oic.oauth2.message import MissingRequiredAttribute
 from oic.oauth2.message import OauthMessageFactory
@@ -625,6 +627,19 @@ class TestClient(object):
 
         assert isinstance(resp, AccessTokenResponse)
         assert resp["access_token"] == "Token"
+
+    def test_parse_request_response_should_return_status_code_if_content_length_zero(
+        self,
+    ):
+
+        resp = requests.Response()
+        resp.headers = requests.models.CaseInsensitiveDict(data={"content-length": "0"})
+        resp.status_code = 200
+        parsed_response = self.client.parse_request_response(
+            reqresp=resp, response=Message, body_type=""
+        )
+
+        assert parsed_response == 200
 
 
 class TestServer(object):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -204,14 +204,15 @@ def test_match_to():
 def test_verify_header():
     class FakeResponse:
         def __init__(self, header):
-            self.headers = {"content-type": header}
+            self.headers = header
             self.text = "TEST_RESPONSE"
 
-    json_header = "application/json"
-    jwt_header = "application/jwt"
-    default_header = util.DEFAULT_POST_CONTENT_TYPE
-    plain_text_header = "text/plain"
-    undefined_header = "undefined"
+    json_header = {"content-type": "application/json"}
+    jwt_header = {"content-type": "application/jwt"}
+    default_header = {"content-type": util.DEFAULT_POST_CONTENT_TYPE}
+    plain_text_header = {"content-type": "text/plain"}
+    undefined_header = {"content-type": "undefined"}
+    zero_content_length_header = {"content-length": "0"}
 
     assert util.verify_header(FakeResponse(json_header), "json") == "json"
     assert util.verify_header(FakeResponse(jwt_header), "json") == "jwt"
@@ -223,6 +224,7 @@ def test_verify_header():
         util.verify_header(FakeResponse(plain_text_header), "urlencoded")
         == "urlencoded"
     )
+    assert util.verify_header(FakeResponse(zero_content_length_header), "") is None
 
     with pytest.raises(ValueError):
         util.verify_header(FakeResponse(json_header), "urlencoded")

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -177,15 +177,21 @@ def test_pkce_token():
 @responses.activate
 def test_do_token_revocation():
     request_args = {
-        'token': 'access_token',
-        'token_type_hint': 'access_token',
-        'client_id': 'client_id',
-        'client_secret': 'client_secret'
+        "token": "access_token",
+        "token_type_hint": "access_token",
+        "client_id": "client_id",
+        "client_secret": "client_secret",
     }
     token_revocation_endpoint = "https://example.com/revoke"
     # Mock zero content length body.
-    responses.add(responses.POST, token_revocation_endpoint, body='', status=200,
-                  headers={'content-length': '0'})
-    resp = Client().do_token_revocation(request_args=request_args,
-                                        endpoint=token_revocation_endpoint)
+    responses.add(
+        responses.POST,
+        token_revocation_endpoint,
+        body="",
+        status=200,
+        headers={"content-length": "0"},
+    )
+    resp = Client().do_token_revocation(
+        request_args=request_args, endpoint=token_revocation_endpoint
+    )
     assert resp == 200

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qs
+
 import responses
 
 from oic import rndstr
@@ -194,4 +196,7 @@ def test_do_token_revocation():
     resp = Client().do_token_revocation(
         request_args=request_args, endpoint=token_revocation_endpoint
     )
+    parsed_request: dict = parse_qs(responses.calls[0].request.body)
     assert resp == 200
+    assert parsed_request['token'] == ['access_token']
+    assert parsed_request['token_type_hint'] == ['access_token']

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -198,5 +198,5 @@ def test_do_token_revocation():
     )
     parsed_request: dict = parse_qs(responses.calls[0].request.body)
     assert resp == 200
-    assert parsed_request['token'] == ['access_token']
-    assert parsed_request['token_type_hint'] == ['access_token']
+    assert parsed_request["token"] == ["access_token"]
+    assert parsed_request["token_type_hint"] == ["access_token"]

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -1,3 +1,5 @@
+import responses
+
 from oic import rndstr
 from oic.extension.client import Client
 from oic.extension.provider import Provider
@@ -170,3 +172,20 @@ def test_pkce_token():
     _info = constructor.get_info(access_grant)
     assert _info["code_challenge_method"] == args["code_challenge_method"]
     assert _info["code_challenge"] == args["code_challenge"]
+
+
+@responses.activate
+def test_do_token_revocation():
+    request_args = {
+        'token': 'access_token',
+        'token_type_hint': 'access_token',
+        'client_id': 'client_id',
+        'client_secret': 'client_secret'
+    }
+    token_revocation_endpoint = "https://example.com/revoke"
+    # Mock zero content length body.
+    responses.add(responses.POST, token_revocation_endpoint, body='', status=200,
+                  headers={'content-length': '0'})
+    resp = Client().do_token_revocation(request_args=request_args,
+                                        endpoint=token_revocation_endpoint)
+    assert resp == 200


### PR DESCRIPTION
The `content-type` in the header is optional when the payload has zero content length. See, [Should Content-Type header be present when the message body is empty?](https://stackoverflow.com/questions/29784398/should-content-type-header-be-present-when-the-message-body-is-empty).

This happens when the request to IdP is made for revoking tokens. In that case, IdP returns a `200 OK` status code with no body and no  `Content-Type` in the response header.

See, [About the revoke request](https://developer.okta.com/docs/guides/revoke-tokens/main/#about-the-revoke-request).

> Revoking a token that is invalid, expired, or already revoked returns a 200 OK status code to prevent any information leaks.

To parse responses with zero content length, just check if the value of `content-length` is 0 and return the status code if it does.