### PR TITLE
Fixed KeyError In Client Registration Info

### DIFF
--- a/src/oic/extension/client.py
+++ b/src/oic/extension/client.py
@@ -340,9 +340,9 @@ class Client(oauth2.Client):
 
     def store_registration_info(self, reginfo):
         self.registration_response = reginfo
-        self.client_secret = reginfo["client_secret"]
-        self.client_id = reginfo["client_id"]
-        self.redirect_uris = reginfo["redirect_uris"]
+        self.client_secret = reginfo.get("client_secret")
+        self.client_id = reginfo.get("client_id")
+        self.redirect_uris = reginfo.get("redirect_uris")
 
     def handle_registration_info(self, response):
         if response.status_code in SUCCESSFUL:

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -6,6 +6,7 @@ from oic import rndstr
 from oic.extension.client import Client
 from oic.extension.provider import Provider
 from oic.extension.token import JWTToken
+from oic.oic.message import RegistrationResponse
 from oic.utils.authn.authn_context import AuthnBroker
 from oic.utils.authn.client import verify_client
 from oic.utils.authn.user import UserAuthnMethod
@@ -200,3 +201,22 @@ def test_do_token_revocation():
     assert resp == 200
     assert parsed_request["token"] == ["access_token"]
     assert parsed_request["token_type_hint"] == ["access_token"]
+
+
+def test_store_registration_info():
+    registration_response_args = {
+        "client_id": "client_id",
+        "client_secret": "client_secret",
+        "redirect_uris": [
+            "https://example.com/redirect_uri1",
+            "https://example.com/redirect_uri2",
+        ],
+    }
+    reginfo = RegistrationResponse(**registration_response_args)
+    client = Client()
+    client.store_registration_info(reginfo=reginfo)
+
+    assert client.registration_response == reginfo
+    assert client.client_id == registration_response_args["client_id"]
+    assert client.client_secret == registration_response_args["client_secret"]
+    assert client.redirect_uris == registration_response_args["redirect_uris"]

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands =
     pydocstyle src
     mypy --config-file mypy.ini src/ tests/
     black src/ tests/ --check -t py36
-    python3 setup.py --quiet sdist
+    python setup.py --quiet sdist
     bandit -a file -r src/ oauth_example/ oidc_example/
     twine check dist/*
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands =
     pydocstyle src
     mypy --config-file mypy.ini src/ tests/
     black src/ tests/ --check -t py36
-    python setup.py --quiet sdist
+    python3 setup.py --quiet sdist
     bandit -a file -r src/ oauth_example/ oidc_example/
     twine check dist/*
 


### PR DESCRIPTION
When registration info has redirect_uri missing, it raises `KeyError` exception when method `store_registration_info` of class `oic.extension.Client` is called. Use `get` to access value so that by default it returns `None` if the key is missing.