### PR TITLE
Try to fix the generic response parsing and handling

### DIFF
--- a/src/oic/extension/client.py
+++ b/src/oic/extension/client.py
@@ -8,7 +8,6 @@ from oic import oauth2
 from oic import unreserved
 from oic.exception import AuthzError
 from oic.exception import PyoidcError
-
 from oic.extension.message import ClientRegistrationError
 from oic.extension.message import ExtensionMessageFactory
 from oic.oauth2.exception import Unsupported

--- a/src/oic/extension/client.py
+++ b/src/oic/extension/client.py
@@ -8,6 +8,7 @@ from oic import oauth2
 from oic import unreserved
 from oic.exception import AuthzError
 from oic.exception import PyoidcError
+
 from oic.extension.message import ClientRegistrationError
 from oic.extension.message import ExtensionMessageFactory
 from oic.oauth2.exception import Unsupported
@@ -146,7 +147,7 @@ class Client(oauth2.Client):
         if http_args is None:
             http_args = ht_args
         else:
-            http_args.update(http_args)
+            http_args.update(ht_args)
 
         resp = self.request_and_return(
             url, response_cls, method, body, body_type, http_args=http_args
@@ -266,7 +267,7 @@ class Client(oauth2.Client):
 
     def do_token_revocation(
         self,
-        body_type="",
+        body_type=None,
         method="POST",
         request_args=None,
         extra_args=None,
@@ -274,17 +275,44 @@ class Client(oauth2.Client):
         **kwargs,
     ):
         request = self.message_factory.get_request_type("revocation_endpoint")
-        response_cls = self.message_factory.get_response_type("revocation_endpoint")
-        return self.do_op(
-            request=request,
-            body_type=body_type,
-            method=method,
-            request_args=request_args,
-            extra_args=extra_args,
-            http_args=http_args,
-            response_cls=response_cls,
-            **kwargs,
+        # There is no expected response, only the status code is important,
+        # so do not use do_op().
+
+        url, body, ht_args, _ = self.request_info(
+            request, method, request_args, extra_args, **kwargs
         )
+
+        if http_args is None:
+            http_args = ht_args
+        else:
+            http_args.update(ht_args)
+
+        resp = self.http_request(url, method, data=body, **http_args)
+
+        if resp.status_code == 200:
+            return 200
+        if resp.status_code == 503:
+            # Revoke failed, should retry later
+            raise PyoidcError("Retry revocation later.")
+
+        if 400 <= resp.status_code < 500:
+            # check for error response
+            try:
+                err = ErrorResponse().deserialize(resp.text)
+                try:
+                    err.verify()
+                except PyoidcError:
+                    pass
+                else:
+                    return err
+            except Exception:
+                logger.exception(
+                    "Failed to decode error response (%d) %s",
+                    resp.status_code,
+                    sanitize(resp.text),
+                )
+
+        return resp
 
     def add_code_challenge(self):
         try:

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -762,7 +762,7 @@ class Client(PBase):
             if body_type == "txt":
                 body_type = "urlencoded"
             try:
-                err = ErrorResponse().deserialize(reqresp.message, method=body_type)
+                err = ErrorResponse().deserialize(reqresp.text, method=body_type)
                 try:
                     err.verify()
                 except PyoidcError:

--- a/src/oic/oauth2/base.py
+++ b/src/oic/oauth2/base.py
@@ -4,6 +4,7 @@ import warnings
 from http import cookiejar as cookielib
 from http.cookies import CookieError
 from http.cookies import SimpleCookie
+from typing import cast
 
 import requests
 
@@ -103,7 +104,7 @@ class PBase(object):
 
         return cookie_dict
 
-    def http_request(self, url, method="GET", **kwargs):
+    def http_request(self, url: str, method="GET", **kwargs) -> requests.Response:
         """
         Run a HTTP request to fetch the given url.
 
@@ -117,8 +118,7 @@ class PBase(object):
 
         """
         _kwargs = copy.copy(self.request_args)
-        if kwargs:
-            _kwargs.update(kwargs)
+        _kwargs.update(kwargs)
 
         if self.cookiejar:
             _kwargs["cookies"] = self._cookies()
@@ -129,7 +129,10 @@ class PBase(object):
 
         try:
             if getattr(self.settings, "requests_session", None) is not None:
-                r = self.settings.requests_session.request(method, url, **_kwargs)  # type: ignore
+                r = cast(
+                    requests.Response,
+                    self.settings.requests_session.request(method, url, **_kwargs),  # type: ignore
+                )
             else:
                 r = requests.request(method, url, **_kwargs)  # type: ignore
         except Exception as err:

--- a/src/oic/oauth2/util.py
+++ b/src/oic/oauth2/util.py
@@ -3,9 +3,13 @@ from http import cookiejar as http_cookiejar
 from http.cookiejar import http2time  # type: ignore
 from typing import Any
 from typing import Dict
+from typing import Optional
 from urllib.parse import parse_qs
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
+
+import requests
+from typing_extensions import Literal
 
 from oic.exception import UnSupported
 from oic.oauth2.exception import TimeFormatError
@@ -45,6 +49,9 @@ ATTRS: Dict[str, Any] = {
     "rest": "",
     "rfc2109": True,
 }
+
+# The encodings understood by our Message class
+ENCODINGS = Literal["json", "urlencoded", "dict", "jwt", "jwe"]
 
 
 def get_or_post(
@@ -180,23 +187,39 @@ def match_to_(val, vlist):
     return False
 
 
-def verify_header(reqresp, body_type):
+def guess_body_type(reqresp: requests.Response):
+    """
+    Try to guess the body type of the message from a response object
+    """
+    # try to handle chunked responses.
+    if "chunked" not in reqresp.headers.get("transfer-encoding", ""):
+        if int(reqresp.headers["content-length"]) == 0:
+            return None
+
+    _ctype = reqresp.headers["content-type"]
+    if match_to_("application/json", _ctype):
+        body_type = "json"
+    elif match_to_("application/jwt", _ctype):
+        body_type = "jwt"
+    elif match_to_("application/jwe", _ctype):
+        body_type = "jwe"
+    elif match_to_(URL_ENCODED, _ctype):
+        body_type = "urlencoded"
+    else:
+        body_type = None
+    return body_type
+
+
+def verify_header(
+    reqresp: requests.Response, body_type: Optional[ENCODINGS]
+) -> Optional[ENCODINGS]:
     logger.debug("resp.headers: %s" % (sanitize(reqresp.headers),))
     logger.debug("resp.txt: %s" % (sanitize(reqresp.text),))
 
-    if body_type == "":
-        if int(reqresp.headers["content-length"]) == 0:
-            return None
-        _ctype = reqresp.headers["content-type"]
-        if match_to_("application/json", _ctype):
-            body_type = "json"
-        elif match_to_("application/jwt", _ctype):
-            body_type = "jwt"
-        elif match_to_(URL_ENCODED, _ctype):
-            body_type = "urlencoded"
-        else:
-            body_type = "txt"  # reasonable default ??
-    elif body_type == "json":
+    if body_type is None:
+        return guess_body_type(reqresp)
+
+    if body_type == "json":
         if not match_to_("application/json", reqresp.headers["content-type"]):
             if match_to_("application/jwt", reqresp.headers["content-type"]):
                 body_type = "jwt"

--- a/src/oic/oauth2/util.py
+++ b/src/oic/oauth2/util.py
@@ -8,7 +8,6 @@ from urllib.parse import parse_qs
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
 
-import requests
 from typing_extensions import Literal
 
 from oic.exception import UnSupported

--- a/src/oic/oauth2/util.py
+++ b/src/oic/oauth2/util.py
@@ -187,8 +187,8 @@ def match_to_(val, vlist):
     return False
 
 
-def guess_body_type(reqresp: requests.Response):
-    "Try to guess the body type of the message from a response object"
+def guess_body_type(reqresp):
+    """Try to guess the body type of the message from a response object."""
     # try to handle chunked responses.
     if "chunked" not in reqresp.headers.get("transfer-encoding", ""):
         if int(reqresp.headers["content-length"]) == 0:
@@ -208,9 +208,7 @@ def guess_body_type(reqresp: requests.Response):
     return body_type
 
 
-def verify_header(
-    reqresp: requests.Response, body_type: Optional[ENCODINGS]
-) -> Optional[ENCODINGS]:
+def verify_header(reqresp, body_type: Optional[ENCODINGS]) -> Optional[ENCODINGS]:
     logger.debug("resp.headers: %s" % (sanitize(reqresp.headers),))
     logger.debug("resp.txt: %s" % (sanitize(reqresp.text),))
 

--- a/src/oic/oauth2/util.py
+++ b/src/oic/oauth2/util.py
@@ -188,9 +188,7 @@ def match_to_(val, vlist):
 
 
 def guess_body_type(reqresp: requests.Response):
-    """
-    Try to guess the body type of the message from a response object
-    """
+    "Try to guess the body type of the message from a response object"
     # try to handle chunked responses.
     if "chunked" not in reqresp.headers.get("transfer-encoding", ""):
         if int(reqresp.headers["content-length"]) == 0:

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -2320,7 +2320,7 @@ class Provider(AProvider):
                 logger.info("logging out from {} at {}".format(_cid, _url))
 
                 try:
-                    res = self.httpc.http_request(
+                    resp = self.httpc.http_request(
                         _url,
                         "POST",
                         data="logout_token={}".format(sjwt),
@@ -2334,7 +2334,7 @@ class Provider(AProvider):
                     failed.append(_cid)
                     continue
 
-                if res.status_code < 300:
+                if resp.status_code < 300:
                     logger.info("Logged out from {}".format(_cid))
                 else:
                     _errstr = "failed to logout from {}".format(_cid)

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -5,7 +5,6 @@ from urllib.parse import urlencode
 from urllib.parse import urlparse
 
 import pytest
-import requests
 import responses
 
 from oic.oauth2 import Client
@@ -26,7 +25,6 @@ from oic.oauth2.message import ErrorResponse
 from oic.oauth2.message import ExtensionTokenRequest
 from oic.oauth2.message import FormatError
 from oic.oauth2.message import GrantExpired
-from oic.oauth2.message import Message
 from oic.oauth2.message import MessageTuple
 from oic.oauth2.message import MissingRequiredAttribute
 from oic.oauth2.message import OauthMessageFactory

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -628,19 +628,6 @@ class TestClient(object):
         assert isinstance(resp, AccessTokenResponse)
         assert resp["access_token"] == "Token"
 
-    def test_parse_request_response_should_return_status_code_if_content_length_zero(
-        self,
-    ):
-
-        resp = requests.Response()
-        resp.headers = requests.models.CaseInsensitiveDict(data={"content-length": "0"})
-        resp.status_code = 200
-        parsed_response = self.client.parse_request_response(
-            reqresp=resp, response=Message, body_type=""
-        )
-
-        assert parsed_response == 200
-
 
 class TestServer(object):
     @pytest.fixture(autouse=True)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -213,6 +213,10 @@ def test_verify_header():
     plain_text_header = {"content-type": "text/plain"}
     undefined_header = {"content-type": "undefined"}
     zero_content_length_header = {"content-length": "0"}
+    chunked_header_json = {
+        "transfer-encoding": "chunked",
+        "content-type": "application/json",
+    }
 
     assert util.verify_header(FakeResponse(json_header), "json") == "json"
     assert util.verify_header(FakeResponse(jwt_header), "json") == "jwt"
@@ -224,7 +228,8 @@ def test_verify_header():
         util.verify_header(FakeResponse(plain_text_header), "urlencoded")
         == "urlencoded"
     )
-    assert util.verify_header(FakeResponse(zero_content_length_header), "") is None
+    assert util.verify_header(FakeResponse(zero_content_length_header), None) is None
+    assert util.verify_header(FakeResponse(chunked_header_json), None) == "json"
 
     with pytest.raises(ValueError):
         util.verify_header(FakeResponse(json_header), "urlencoded")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -237,7 +237,7 @@ def test_verify_header():
         util.verify_header(FakeResponse(default_header), "json")
         util.verify_header(FakeResponse(plain_text_header), "jwt")
         util.verify_header(FakeResponse(undefined_header), "json")
-        util.verify_header(FakeResponse(json_header), "undefined")
+        util.verify_header(FakeResponse(json_header), "undefined")  # type: ignore
 
 
 class TestRenderTemplate(object):


### PR DESCRIPTION
- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [x] New code is annotated.
- [x] Changes are covered by tests.
---

This tries to cleanup the mess around the error handling in: https://github.com/OpenIDC/pyoidc/issues/807

The parse_request_response() method of the client has some horribly mixed return type for some very limited special cases. This change tries to untangle that mess a bit, by reducing the return types to just Message or requests.Response.

The special handling of an empty response is instead pushed to the Token Revocation code in the extension client that needs it.


