### PR TITLE
Fixed RP-Initiated Logout To Accept id_token_hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,17 @@ The format is based on the [KeepAChangeLog] project.
 ### Changed
 - [#827] Added support for python 3.11
 
+### Fixed
+- [#826], [#829] Fixed RP-Initiated Logout To Accept id_token_hint
+
 ## Removed
 
 - [#820] Removed Client.grant_from_state method.
 
 [#820]: https://github.com/OpenIDC/pyoidc/pull/820
 [#827]: https://github.com/OpenIDC/pyoidc/issues/827
+[#826]: https://github.com/OpenIDC/pyoidc/issues/826
+[#829]: https://github.com/OpenIDC/pyoidc/pull/829
 
 ## 1.4.0 [2022-05-23]
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 check_untyped_defs = True
+no_implicit_optional = False
 
 [mypy-jwkest.*]
 ignore_missing_imports = True

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -647,7 +647,12 @@ class Client(oauth2.Client):
         )
 
     def construct_EndSessionRequest(
-        self, request=None, request_args=None, extra_args=None, **kwargs
+        self,
+        request=None,
+        request_args=None,
+        extra_args=None,
+        prop="id_token_hint",
+        **kwargs,
     ):
 
         if request is None:
@@ -658,7 +663,9 @@ class Client(oauth2.Client):
         if "state" in request_args and "state" not in kwargs:
             kwargs["state"] = request_args["state"]
 
-        return self._id_token_based(request, request_args, extra_args, **kwargs)
+        return self._id_token_based(
+            request, request_args, extra_args, prop=prop, **kwargs
+        )
 
     def do_authorization_request(
         self,
@@ -824,6 +831,7 @@ class Client(oauth2.Client):
         request_args=None,
         extra_args=None,
         http_args=None,
+        prop="id_token_hint",
     ):
         request = self.message_factory.get_request_type("endsession_endpoint")
         response_cls = self.message_factory.get_response_type("endsession_endpoint")
@@ -834,6 +842,7 @@ class Client(oauth2.Client):
             extra_args=extra_args,
             scope=scope,
             state=state,
+            prop=prop,
         )
 
         if http_args is None:


### PR DESCRIPTION
Addresses #826 

According to [OIDC specs on RP-Initiated logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html), the expected arguments are  `post_logout_redirect_uri` and `id_token_hint` that accepts raw ID token JWT.

Added a default parameter `id_token_hint` in `oic.Client.construct_EndSessionRequest` & `oic.Client.do_end_session_request` to make them comply with OIDC specs.