### PR TITLE
Don't throw exception for token error response.

### DIFF
--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -743,14 +743,7 @@ class Client(PBase):
             logger.error("(%d) %s" % (reqresp.status_code, sanitize(reqresp.text)))
             raise ParseError("ERROR: Something went wrong: %s" % reqresp.text)
 
-        if reqresp.status_code in SUCCESSFUL:
-            verified_body_type = verify_header(reqresp, body_type)
-        elif (
-            reqresp.status_code in [400, 401]
-            and response
-            and issubclass(response, ErrorResponse)
-        ):
-            # This is okay if we are expecting an error response, do not log
+        if reqresp.status_code in SUCCESSFUL or (reqresp.status_code in [400, 401] and response):
             verified_body_type = verify_header(reqresp, body_type)
         else:
             # Any other error

--- a/src/oic/oauth2/__init__.py
+++ b/src/oic/oauth2/__init__.py
@@ -743,7 +743,9 @@ class Client(PBase):
             logger.error("(%d) %s" % (reqresp.status_code, sanitize(reqresp.text)))
             raise ParseError("ERROR: Something went wrong: %s" % reqresp.text)
 
-        if reqresp.status_code in SUCCESSFUL or (reqresp.status_code in [400, 401] and response):
+        if reqresp.status_code in SUCCESSFUL or (
+            reqresp.status_code in [400, 401] and response
+        ):
             verified_body_type = verify_header(reqresp, body_type)
         else:
             # Any other error


### PR DESCRIPTION
- [x] Changes are covered by tests.
---

When upgrading the `pyoidc` dependency from `1.4.0` to `1.5.0` in [Flask-pyoidc](https://github.com/zamzterz/Flask-pyoidc) it revealed a breaking API change (by breaking [this test](https://github.com/zamzterz/Flask-pyoidc/blob/6c55fbe304a39902a9c6374fd560845218461382/tests/test_pyoidc_facade.py#L205)): A`HttpError` exception is thrown for token error responses, without any possibility of recovering the error response.

This change brings back the [behavior in `1.4.0`](https://github.com/OpenIDC/pyoidc/blob/1.4.0/src/oic/oauth2/__init__.py#L738-L741) which returns the token error response allowing for further handling.